### PR TITLE
[FIX] OS Link Error when moving author file due to different filesystems

### DIFF
--- a/cookietemple/create/create_templates.py
+++ b/cookietemple/create/create_templates.py
@@ -128,7 +128,8 @@ def create_common_files() -> None:
         else:
             if is_dir:
                 delete_dir_tree(poss_dir)
-            path.replace(f"{cwd_project}/{TEMPLATE_STRUCT['project_slug']}/{f}")
+            shutil.copy(path, f"{cwd_project}/{TEMPLATE_STRUCT['project_slug']}/{f}")
+            os.remove(path)
 
     delete_dir_tree(Path(f'{Path.cwd()}/common_files_util'))
     shutil.rmtree(dirpath)


### PR DESCRIPTION
Issue: https://github.com/Zethson/cookietemple/issues/99
Path.replace internally uses renames to move files. This does not work
on Systems which implement tmp as another file system as the main
filesystem. On Unix Systems, /tmp is sometimes implemented as tmpfs,
while the main fs is usually ext4. Simply copying and removing the file
fixes this.

Closes #99.