### PR TITLE
[#234] OS-specific config location under a cookietemple directory: BREAKING CHANGE

### DIFF
--- a/cookietemple/config/config.py
+++ b/cookietemple/config/config.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import click
+import appdirs
 from pathlib import Path
 from cryptography.fernet import Fernet
 from ruamel.yaml import YAML
@@ -13,13 +14,15 @@ class ConfigCommand:
     Class for the config command. Sets general configurations such as full name, email and Github username.
     """
     # path where the config file is stored for cookietemple
-    CONF_FILE_PATH = f'{Path.home()}/.config/cookietemple_conf.yml'
-    KEY_PAT_FILE = f'{Path.home()}/.config/.ct_keys'
+    CONF_FILE_PATH = f'{appdirs.user_config_dir(appname="cookietemple")}/cookietemple_cfg.yml'
+    KEY_PAT_FILE = f'{appdirs.user_config_dir(appname="cookietemple")}/.ct_keys'
+
     @staticmethod
     def all_settings() -> None:
         """
         Set general settings and PAT.
         """
+        ConfigCommand.check_ct_config_dir_exists()
         ConfigCommand.config_general_settings()
         ConfigCommand.config_pat()
 
@@ -28,6 +31,7 @@ class ConfigCommand:
         """
         Set full_name and email for reuse in any project created further on.
         """
+        ConfigCommand.check_ct_config_dir_exists()
         full_name = click.prompt('Please enter your full name', type=str, default='Homer Simpson')
         email = click.prompt('Please enter your personal or work email', type=str, default='homer.simpson@example.com')
         github_username = click.prompt('Please enter your github username', type=str)
@@ -55,6 +59,7 @@ class ConfigCommand:
         """
         Set the personal access token (PAT) for automatic Github repo creation.
         """
+        ConfigCommand.check_ct_config_dir_exists()
         try:
             path = Path(ConfigCommand.CONF_FILE_PATH)
             yaml = YAML(typ='safe')
@@ -121,6 +126,14 @@ class ConfigCommand:
             # unknown handle and no best match found
             click.echo(click.style('Unknown handle ', fg='red') + click.style(section, fg='green')
                        + click.style(' See cookietemple --help for info on valid handles', fg='red'))
+
+    @staticmethod
+    def check_ct_config_dir_exists() -> None:
+        """
+        Check if the config directory for cookietemple exists. If not, create it.
+        """
+        if not os.path.exists(Path(ConfigCommand.CONF_FILE_PATH).parent):
+            os.mkdir(Path(ConfigCommand.CONF_FILE_PATH).parent)
 
     @staticmethod
     def handle_switcher() -> dict:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ cryptography==2.9.2
 requests==2.23.0
 rich==2.2.2
 packaging==20.4
+appdirs==1.4.4


### PR DESCRIPTION
Many thanks for contributing to COOKIETEMPLE!

**Associated Template/Command/Core**
Config and create

**Description of changes**
Changed config file location to make it OS-specific and locate them in the OS-specific config path under a cookietemple directory

**Technical details**
This is a BREAKING CHANGE. Every config data used in an earlier version will not be used anymore.

@Zethson @filipdutescu 