### PR TITLE
[#254] Fixed insertion order for bump-version changelog

### DIFF
--- a/cookietemple/bump_version/bump_version.py
+++ b/cookietemple/bump_version/bump_version.py
@@ -143,7 +143,7 @@ class VersionBumper:
         :return: True if bump version can be run, false otherwise.
         """
         # ensure that the entered version number matches correct format like 1.1.0 or 1.1.0-SNAPSHOT but not 1.2 or 1.2.3.4
-        if not re.match(r'(?<!\.)\d+(?:\.\d+){2}((?!.)|-SNAPSHOT)(?!\.)', new_version):
+        if not re.match(r'(?<!\.)\d+(?:\.\d+){2}((?!.)|-SNAPSHOT)(?!.)', new_version):
             click.echo(click.style('Invalid version specified!\nEnsure your version number has the form '
                                    'like 0.0.0 or 15.100.239-SNAPSHOT', fg='red'))
             return False


### PR DESCRIPTION
- fixed a bug that lead to false error message when calling bump-version
  with versions like 2.0.0MYTXT or MYTEXT1.2.3

- calling bump-version will now only work with a version like 2.0.0 or
  2.0.0-SNAPSHOT, everything else is permitted

Many thanks for contributing to COOKIETEMPLE!

**Associated Template/Command/Core**
State the template handle (e.g. python-cli) and also add it in the title.
If your pull request is not directly related to any template, please state either the associated COOKIETEMPLE command or '[CORE]' if it is a general COOKIETEMPLE bug.

**PR Checklist**
Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

 - [ ] This comment contains a description of changes (with reason)
 - [ ] Referenced issue is linked
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.rst` is updated

**Description of changes**
Please state what you've changed and how it might affect the user.

**Technical details**
Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here.

**Additional context**
Add any other context or screenshots here.
