### PR TITLE
[LIB-CPP] Fixed Lib-Cpp Ubuntu build WF not working

### DIFF
--- a/cookietemple/create/templates/lib/lib_cpp/{{ cookiecutter.project_slug }}/.github/workflows/build_linux.yml
+++ b/cookietemple/create/templates/lib/lib_cpp/{{ cookiecutter.project_slug }}/.github/workflows/build_linux.yml
@@ -38,7 +38,7 @@ jobs:
         cd ../{{ cookiecutter.project_slug }}
 
     - name: configure
-      run: cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/$INSTALL_LOCATION -D{ cookiecutter.project_slug }_ENABLE_CODE_COVERAGE=1
+      run: cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/$INSTALL_LOCATION -D{{ cookiecutter.project_slug }}_ENABLE_CODE_COVERAGE=1
       
     - name: build
       run: cmake --build build --config $BUILD_TYPE -j4


### PR DESCRIPTION
Fixes #370 

**Lib-Cpp**

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

 - [x] This comment contains a description of changes (with reason)
 - [x] Referenced issue is linked
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.rst` is updated

**Description of changes**

Fixed a bug in the Ubuntu build workflow of `lib-cpp`, which caused it to fail.

**Technical details**

N/A

**Additional context**

Error was caused by using an improper `cookiecutter` syntax for replacing the project name in the workflow.
