### PR TITLE
Fix #480 Inital version prompt

### DIFF
--- a/cookietemple/create/template_creator.py
+++ b/cookietemple/create/template_creator.py
@@ -221,7 +221,7 @@ class TemplateCreator:
                                                                  to_get_property='version')
 
         # make sure that the version has the right format
-        while not re.match(r'(?<!\.)\d+(?:\.\d+){2}(?:-SNAPSHOT)?(?!\.)', poss_vers) and not dot_cookietemple:
+        while not re.match(r'(?<!.)\d+(?:\.\d+){2}(?:-SNAPSHOT)?(?!.)', poss_vers) and not dot_cookietemple:
             print('[bold red]The version number entered does not match semantic versioning.\n' +
                   'Please enter the version in the format \[number].\[number].\[number]!')  # noqa: W605
             poss_vers = cookietemple_questionary_or_dot_cookietemple(function='text',


### PR DESCRIPTION
- fixed a bug, where the initial version prompt accepted strings like mystr1.2.3 or 1.2.3mystr as valid version numbers

- only allowed version numbers now: 1.2.3 or 1.2.3-SNAPSHOT