### PR TITLE
Release/1.2.0

### DIFF
--- a/.cookietemple.yml
+++ b/.cookietemple.yml
@@ -7,7 +7,7 @@ project_name: cookietemple
 project_slug: cookietemple
 project_slug_no_hyphen: cookietemple
 project_short_description: A cookiecutter based project template creation tool supporting several domains and languages with linting and template sync support.
-version: 1.0.1
+version: 1.2.0
 license: MIT
 github_username: cookiejar
 creator_github_username: Zethson

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,7 +18,7 @@ assignees: ''
 **To Reproduce**
 
 Steps to reproduce the behavior:
-1. Run COOKIETEMPLE with command: '...'
+1. Run cookietemple with command: '...'
 2. Select: '...'
 3. See error
 
@@ -31,7 +31,7 @@ Steps to reproduce the behavior:
  - OS: e.g. [Ubuntu 18.04]
  - Python: [e.g. 3.8]
  - Virtual environment: [e.g. Conda]
- - COOKIETEMPLE: [e.g. 1.0.0]
+ - cookietemple: [e.g. 1.0.0]
 
 **Additional context**
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,15 @@ updates:
   - dependabot
   commit-message:
     prefix: "[DEPENDABOT]"
+    
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 99
+  target-branch: development
+  labels:
+  - dependabot
+  commit-message:
+    prefix: "[DEPENDABOT]"

--- a/.github/workflows/create_cli_java.yml
+++ b/.github/workflows/create_cli_java.yml
@@ -33,8 +33,8 @@ jobs:
           cd ..
           echo -e "\n\033[B\nHomer\nhomer.simpson@hotmail.com\nhomergithub\nnExplodingSpringfield\ndescription\n1.0.0\n\ngroup_domain\ngroup_organization\nn" | cookietemple create
 
-      - uses: actions/checkout@v1
-      - uses: DeLaGuardo/setup-graalvm@2.0
+      - uses: actions/checkout@v2
+      - uses: DeLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
         with:
           graalvm-version: '20.1.0.java11'
       - run: java -version

--- a/.github/workflows/pr_to_master_from_patch_release_only.yml
+++ b/.github/workflows/pr_to_master_from_patch_release_only.yml
@@ -1,4 +1,4 @@
-name: PR to master branch from PATCH/release branch only
+name: PR to master branch from patch/release branch only
 
 on:
   pull_request:
@@ -6,12 +6,29 @@ on:
     - master
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Check if PR branch to master is PATCH or release branch
+      # PRs to the repository master branch are only ok if coming from any patch or release branch
+      - name: Check PRs
         run: |
-            branch=$(echo "${{ github.event.pull_request.head.ref }}" | tr '[:upper:]' '[:lower:]')
-            echo "Pull request's branch to be merged is: ${{ github.event.pull_request.head.ref  }}"
-            if [[ "$branch" != *"patch"* ]] && [[ "$branch" != *"release"* ]]; then echo "PRs only from patch or release branch to master"; exit 1; fi
+          { [[ $GITHUB_HEAD_REF = *"release"* ]]; } || [[ $GITHUB_HEAD_REF == *"patch"* ]]
+
+      # If the above check failed, post a comment on the PR explaining the failure
+      # NOTE - this may not work if the PR is coming from a fork, due to limitations in GitHub actions secrets
+      - name: Post PR comment
+        if: failure()
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            Hi @${{ github.event.pull_request.user.login }},
+
+            It looks like this pull-request is has been made against the ${{github.event.pull_request.head.repo.full_name}} `master` branch.
+            The `master` branch should always contain code from the latest release.
+            Because of this, PRs to `master` are only allowed if they come from any ${{github.event.pull_request.head.repo.full_name}} `release` or `patch` branch.
+
+            You do not need to close this PR, you can change the target branch to `development` by clicking the _"Edit"_ button at the top of this page.
+
+            Thanks again for your contribution!
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: false

--- a/.github/workflows/run_mypy.yml
+++ b/.github/workflows/run_mypy.yml
@@ -1,0 +1,29 @@
+name: Run mypy checks
+
+on:
+  push:
+    paths:
+      - "**/*.py"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"
+
+    steps:
+      - uses: actions/checkout@v2
+        name: Check out source-code repository
+
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+
+      - name: Install pip
+        run: |
+            python -m pip install --upgrade pip
+
+      - name: Lint with mypy
+        run: |
+            pip install mypy
+            mypy . --show-error-codes

--- a/.github/workflows/sync_project.yml
+++ b/.github/workflows/sync_project.yml
@@ -23,7 +23,7 @@ jobs:
               token: '${{ secrets.CT_SYNC_TOKEN }}'
           name: Check out source-code repository
 
-        - uses: oleksiyrudenko/gha-git-credentials@v1
+        - uses: oleksiyrudenko/gha-git-credentials@v2
           with:
                name: 'zethson'
                email: 'lukas.heumos@posteo.net'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,12 +10,20 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 ------------------
 
 **Added**
+linter for cookietemple.cfg file to ensure integrity
+a path parameter to create projects on other locations than the CWD
 
 **Fixed**
+sync workflow
+java templates WFs due to a GithubActions update
+default branch creation when creating and pushing a project to GitHub
+updated documentation
+web template deployment script (refactored) and workflows
 
 **Dependencies**
 
 **Deprecated**
+GitHub PAT with only repo scope (needs workflows permissions now too)
 
 
 1.0.1 (2020-11-03)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,18 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.2.0 (2020-11-22)
+------------------
+
+**Added**
+
+**Fixed**
+
+**Dependencies**
+
+**Deprecated**
+
+
 1.0.1 (2020-11-03)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,20 +10,23 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 ------------------
 
 **Added**
-linter for cookietemple.cfg file to ensure integrity
-a path parameter to create projects on other locations than the CWD
+
+* a linter for cookietemple.cfg file to ensure integrity
+* a path parameter to create projects on other locations than the CWD
 
 **Fixed**
-sync workflow
-java templates WFs due to a GithubActions update
-default branch creation when creating and pushing a project to GitHub
-updated documentation
-web template deployment script (refactored) and workflows
+
+* sync workflow (try to create a PR against development or, if none, default branch)
+* java templates WFs due to a GithubActions update
+* default branch creation when creating and pushing a project to GitHub
+* web template deployment script (refactored) and workflows
+* updated documentation
 
 **Dependencies**
 
 **Deprecated**
-GitHub PAT with only repo scope (needs workflows permissions now too)
+
+* GitHub PAT with only repo scope (needs workflows permissions now too)
 
 
 1.0.1 (2020-11-03)

--- a/README.rst
+++ b/README.rst
@@ -27,8 +27,8 @@
         :target: https://cookietemple.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
-.. image:: https://codecov.io/gh/Zethson/cookietemple/branch/master/graph/badge.svg?token=dijn0M0p7m
-        :target: https://codecov.io/gh/Zethson/cookietemple
+.. image:: https://codecov.io/gh/cookiejar/cookietemple/branch/master/graph/badge.svg?token=dijn0M0p7m
+        :target: https://codecov.io/gh/cookiejar/cookietemple
         :alt: Codecov Status
 
 .. image:: https://flat.badgen.net/dependabot/thepracticaldev/dev.to?icon=dependabot

--- a/README.rst
+++ b/README.rst
@@ -116,13 +116,15 @@ See `Syncing a project <https://cookietemple.readthedocs.io/en/sync.html>`_.
 warp
 ----
 Create a self contained executable.
-Currently, cookietemple does not ship any templates anymore, where this may be required.
+Currently, cookietemple does not ship any templates, where this may be required.
 
 See `Warping a project <https://cookietemple.readthedocs.io/en/warp.html>`_.
 
 upgrade
 -------
 Check whether you are using the latest cookietemple version and update automatically to benefit from the latest features.
+
+See `Upgrade cookietemple <https://cookietemple.readthedocs.io/en/upgrade.html>`_.
 
 See `<https://cookietemple.readthedocs.io/en/upgrade.html>`_.
 
@@ -144,4 +146,4 @@ Authors
 -------
 
 cookietemple was initiated and developed by `Lukas Heumos (Github)  <https://github.com/zethson>`_ and `Philipp Ehmele (Github) <https://github.com/imipenem>`_.
-A full list of contributors is available on our `statistics webpage <https://cookietemple.com/statistics>`_.
+.. A full list of contributors is available on our `statistics webpage <https://cookietemple.com/statistics>`_.

--- a/cookietemple.cfg
+++ b/cookietemple.cfg
@@ -9,3 +9,9 @@ conf_py = docs/conf.py
 
 [bumpversion_files_blacklisted]
 
+[sync_level]
+ct_sync_level = patch
+
+[sync_files_blacklisted]
+changelog = CHANGELOG.rst
+

--- a/cookietemple.cfg
+++ b/cookietemple.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 1.2.0
 
 [bumpversion_files_whitelisted]
 init_file = cookietemple/__init__.py

--- a/cookietemple/__init__.py
+++ b/cookietemple/__init__.py
@@ -7,4 +7,4 @@
 
 # __version__ = metadata.version('cookietemple')
 
-__version__ = '1.0.1'
+__version__ = '1.2.0'

--- a/cookietemple/bump_version/bump_version.py
+++ b/cookietemple/bump_version/bump_version.py
@@ -2,13 +2,15 @@ import logging
 import os
 import sys
 import re
+from typing import Tuple
+
 from packaging import version
 from configparser import ConfigParser, NoSectionError
 from tempfile import mkstemp
 from shutil import move, copymode
 from os import fdopen, remove
 from pathlib import Path
-from git import Repo
+from git import Repo  # type: ignore
 from datetime import datetime
 from rich import print
 
@@ -98,7 +100,7 @@ class VersionBumper:
             repo.index.commit(f'Bump version from {self.CURRENT_VERSION} to {new_version}')
 
     @staticmethod
-    def replace(file_path: str, subst: str, section: str) -> (bool, str):
+    def replace(file_path: str, subst: str, section: str) -> Tuple[bool, str]:
         """
         Replace a version with the new version unless the line is explicitly excluded (marked with <<COOKIETEMPLE_NO_BUMP>>).
         In case of blacklisted files, bump-version ignores all lines with version numbers unless they´re explicitly marked

--- a/cookietemple/common/levensthein_dist.py
+++ b/cookietemple/common/levensthein_dist.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 from cookietemple.common.suggest_similar_commands import SIMILARITY_SUGGEST_FACTOR, SIMILARITY_USE_FACTOR
 
 
@@ -35,7 +37,7 @@ def levensthein_dist(input_command: str, candidate: str) -> int:
     return dp_table[len(candidate)][len(input_command)]
 
 
-def most_similar_command(command: str, command_list: set) -> (list, str):
+def most_similar_command(command: str, command_list: set) -> Tuple[list, str]:
     """
     This function determines whether its possible to suggest a similar command.
     The similarity is determined by the levensthein distance and a factor (currently 1/3)

--- a/cookietemple/common/load_yaml.py
+++ b/cookietemple/common/load_yaml.py
@@ -10,5 +10,5 @@ def load_yaml_file(yaml_file_path: str) -> dict:
     """
     path = Path(yaml_file_path)
     yaml = YAML()
-    yaml.boolean_representation = ['False', 'True']
+    yaml.boolean_representation = ['False', 'True']  # type: ignore
     return yaml.load(path)

--- a/cookietemple/common/suggest_similar_commands.py
+++ b/cookietemple/common/suggest_similar_commands.py
@@ -1,4 +1,5 @@
 import os
+from typing import Set
 
 from cookietemple.common.load_yaml import load_yaml_file
 from cookietemple.util.dict_util import is_nested_dictionary
@@ -22,8 +23,8 @@ def load_available_handles() -> set:
     :return: A set of all available handles
     """
     available_templates = load_yaml_file(f'{AVAILABLE_TEMPLATES_PATH}')
-    unsplit_handles = set()
-    all_handles = set()
+    unsplit_handles: Set[str] = set()
+    all_handles: Set[str] = set()
     nested_dict_to_handle_set(available_templates, unsplit_handles)
     all_handles.update(unsplit_handles)
     split_handles(unsplit_handles, all_handles)

--- a/cookietemple/common/version.py
+++ b/cookietemple/common/version.py
@@ -1,5 +1,7 @@
 import sys
 from pathlib import Path
+from typing import Tuple
+
 from rich import print
 
 from cookietemple.common.load_yaml import load_yaml_file
@@ -18,10 +20,13 @@ def load_ct_template_version(handle: str, yaml_path: str) -> str:
     if len(parts) == 2:
         return available_templates[parts[0]][parts[1]]['version']
     elif len(parts) == 3:
+
         return available_templates[parts[0]][parts[1]][parts[2]]['version']
 
+    return ''
 
-def load_project_template_version_and_handle(project_dir: Path) -> (str, str):
+
+def load_project_template_version_and_handle(project_dir: Path) -> Tuple[str, str]:
     """
     Load the template version when the user synced its project with cookietemple the last time.
     If no sync has been done so far, its the version of the cookietemple template the user created the project initially with.
@@ -30,11 +35,10 @@ def load_project_template_version_and_handle(project_dir: Path) -> (str, str):
     :param project_dir: Top level directory of the users project.
     :return: The version number of the cookietemple template when the user created the project and the projects template handle.
     """
-    project_dir = str(project_dir)
     try:
-        ct_meta = load_yaml_file(f'{project_dir}/.cookietemple.yml')
-        # split the template version at first space to omit the cookietemple bump-version tag and return it and the the handle
+        ct_meta = load_yaml_file(f'{project_dir.__str__()}/.cookietemple.yml')
+        # split the template version at first space to omit the cookietemple bump-version tag and return it and the handle
         return ct_meta['template_version'].split(" ", 1)[0], ct_meta['template_handle']
     except FileNotFoundError:
-        print(f'[bold red]No .cookietemple.yml found at {project_dir}. Is this a cookietemple project?')
+        print(f'[bold red]No .cookietemple.yml found at {project_dir.__str__()}. Is this a cookietemple project?')
         sys.exit(1)

--- a/cookietemple/config/config.py
+++ b/cookietemple/config/config.py
@@ -96,6 +96,7 @@ class ConfigCommand:
                                                         question='Do you want to configure your GitHub personal access token right now?\n'
                                                         'You can still configure it later by calling    cookietemple config pat',
                                                         default='Yes'):
+            print('[bold blue] cookietemple requires your Github Access token to have full repository and workflow permissions!')
             access_token = cookietemple_questionary_or_dot_cookietemple('password', 'Please enter your Github Access token')
             access_token_b = access_token.encode('utf-8')  # type: ignore
 

--- a/cookietemple/config/config.py
+++ b/cookietemple/config/config.py
@@ -96,7 +96,7 @@ class ConfigCommand:
                                                         question='Do you want to configure your GitHub personal access token right now?\n'
                                                         'You can still configure it later by calling    cookietemple config pat',
                                                         default='Yes'):
-            print('[bold blue] cookietemple requires your Github Access token to have full repository and workflow permissions!')
+            print('[bold blue]cookietemple requires your Github Access token to have full repository and workflow permissions!')
             access_token = cookietemple_questionary_or_dot_cookietemple('password', 'Please enter your Github Access token')
             access_token_b = access_token.encode('utf-8')  # type: ignore
 

--- a/cookietemple/config/config.py
+++ b/cookietemple/config/config.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import sys
-import appdirs
+import appdirs  # type: ignore
 from pathlib import Path
 from cryptography.fernet import Fernet
 from ruamel.yaml import YAML
@@ -97,7 +97,7 @@ class ConfigCommand:
                                                         'You can still configure it later by calling    cookietemple config pat',
                                                         default='Yes'):
             access_token = cookietemple_questionary_or_dot_cookietemple('password', 'Please enter your Github Access token')
-            access_token_b = access_token.encode('utf-8')
+            access_token_b = access_token.encode('utf-8')  # type: ignore
 
             # ask for confirmation since this action will delete the PAT irrevocably if the user has not saved it anywhere else
             if not cookietemple_questionary_or_dot_cookietemple(function='confirm',

--- a/cookietemple/cookietemple_cli.py
+++ b/cookietemple/cookietemple_cli.py
@@ -94,7 +94,7 @@ def create(domain: str) -> None:
 
 
 @cookietemple_cli.command(short_help='Lint your existing cookietemple project.', cls=CustomHelpSubcommand)
-@click.argument('project_dir', type=click.Path(), default=Path(str(Path.cwd())), helpmsg='Relative path to projects directory.', cls=CustomArg)  # type: ignore
+@click.argument('project_dir', type=click.Path(), default=Path(str(Path.cwd())), helpmsg='Path to projects directory.', cls=CustomArg)  # type: ignore
 @click.option('--skip-external', is_flag=True, help='Only run cookietemple linting and not external linters.')
 def lint(project_dir, skip_external) -> None:
     """
@@ -220,7 +220,7 @@ def sync(project_dir, set_token, pat, username, check_update) -> None:
 @cookietemple_cli.command('bump-version', short_help='Bump the version of an existing cookietemple project.', cls=CustomHelpSubcommand)
 @click.argument('new_version', type=str, required=False, helpmsg='New project version in a valid format.', cls=CustomArg)  # type: ignore
 @click.argument('project_dir', type=click.Path(), default=Path(f'{Path.cwd()}'),
-                helpmsg='Relative path to the projects directory.', cls=CustomArg)  # type: ignore
+                helpmsg='Path to the projects directory.', cls=CustomArg)  # type: ignore
 @click.option('--downgrade', '-d', is_flag=True, help='Set this flag to downgrade a version.')
 @click.option('--project-version', is_flag=True, callback=print_project_version, expose_value=False, is_eager=True, help='Print your projects version and exit')
 @click.pass_context
@@ -280,7 +280,7 @@ def warp(input_dir: str, exec: str, output: str) -> None:
     warp_project(input_dir, exec, output)
 
 
-@cookietemple_cli.command(short_help='Configure your general settings and github credentials.', cls=CustomHelpSubcommand)
+@cookietemple_cli.command(short_help='Configure your general settings and Github credentials.', cls=CustomHelpSubcommand)
 @click.option('--view', '-v', is_flag=True, help='View the current cookietemple configuration.')
 @click.argument('section', type=str, required=False, helpmsg='Section to configure (all, general or pat)', cls=CustomArg)  # type: ignore
 @click.pass_context

--- a/cookietemple/cookietemple_cli.py
+++ b/cookietemple/cookietemple_cli.py
@@ -78,9 +78,10 @@ def cookietemple_cli(ctx, verbose, log_file):
 
 
 @cookietemple_cli.command(short_help='Create a new project using one of our templates.', cls=CustomHelpSubcommand)
+@click.argument('path', type=click.Path(), default=Path.cwd(), helpmsg='Path where the project should be created at.', cls=CustomArg)  # type: ignore
 @click.option('--domain', type=click.Choice(['cli', 'lib', 'gui', 'web', 'pub']),
               help='The projects domain with currently cli, lib, gui, web and pub supported.')
-def create(domain: str) -> None:
+def create(path: Path, domain: str) -> None:
     """
     Create a new project using one of our templates.
 
@@ -90,7 +91,7 @@ def create(domain: str) -> None:
     Next, you will be asked whether you want to use cookietemple's Github support create a repository, push your template and enable a few settings.
     After the project has been created it will be linted and you will be notified of any TODOs.
     """
-    choose_domain(domain, None)
+    choose_domain(path, domain, None)
 
 
 @cookietemple_cli.command(short_help='Lint your existing cookietemple project.', cls=CustomHelpSubcommand)

--- a/cookietemple/cookietemple_cli.py
+++ b/cookietemple/cookietemple_cli.py
@@ -94,7 +94,7 @@ def create(domain: str) -> None:
 
 
 @cookietemple_cli.command(short_help='Lint your existing cookietemple project.', cls=CustomHelpSubcommand)
-@click.argument('project_dir', type=click.Path(), default=Path(str(Path.cwd())), helpmsg='Relative path to projects directory.', cls=CustomArg)
+@click.argument('project_dir', type=click.Path(), default=Path(str(Path.cwd())), helpmsg='Relative path to projects directory.', cls=CustomArg)  # type: ignore
 @click.option('--skip-external', is_flag=True, help='Only run cookietemple linting and not external linters.')
 def lint(project_dir, skip_external) -> None:
     """
@@ -123,7 +123,7 @@ def list() -> None:
 
 
 @cookietemple_cli.command(short_help='Get detailed info on a cookietemple template domain or a single template.', cls=CustomHelpSubcommand)
-@click.argument('handle', type=str, required=False, helpmsg='Language/domain of templates of interest.', cls=CustomArg)
+@click.argument('handle', type=str, required=False, helpmsg='Language/domain of templates of interest.', cls=CustomArg)  # type: ignore
 @click.pass_context
 def info(ctx, handle: str) -> None:
     """
@@ -141,11 +141,11 @@ def info(ctx, handle: str) -> None:
 
 
 @cookietemple_cli.command(short_help='Sync your project with the latest template release.', cls=CustomHelpSubcommand)
-@click.argument('project_dir', type=str, default=Path(f'{Path.cwd()}'), helpmsg='The projects top level directory you would like to sync. Default is current '
-                                                                                'working directory.', cls=CustomArg)
-@click.option('--set-token', '-st', is_flag=True, help='Set sync token to a new personal access token of the current repo owner.')
-@click.argument('pat', type=str, required=False, helpmsg='Personal access token. Not needed for manual, local syncing!', cls=CustomArg)
-@click.argument('username', type=str, required=False, helpmsg='Github username. Not needed for manual, local syncing!', cls=CustomArg)
+@click.argument('project_dir', type=str, default=Path(f'{Path.cwd()}'),
+                helpmsg='The projects top level directory you would like to sync. Default is current working directory.', cls=CustomArg)  # type: ignore
+@click.option('--set-token', '-st', is_flag=True, help='Set sync token to a new personal access token of the current repo owner.')  # type: ignore
+@click.argument('pat', type=str, required=False, helpmsg='Personal access token. Not needed for manual, local syncing!', cls=CustomArg)  # type: ignore
+@click.argument('username', type=str, required=False, helpmsg='Github username. Not needed for manual, local syncing!', cls=CustomArg)  # type: ignore
 @click.option('--check-update', '-ch', is_flag=True, help='Check whether a new template version is available for your project.')
 def sync(project_dir, set_token, pat, username, check_update) -> None:
     """
@@ -218,8 +218,9 @@ def sync(project_dir, set_token, pat, username, check_update) -> None:
 
 
 @cookietemple_cli.command('bump-version', short_help='Bump the version of an existing cookietemple project.', cls=CustomHelpSubcommand)
-@click.argument('new_version', type=str, required=False, helpmsg='New project version in a valid format.', cls=CustomArg)
-@click.argument('project_dir', type=click.Path(), default=Path(f'{Path.cwd()}'), helpmsg='Relative path to the projects directory.', cls=CustomArg)
+@click.argument('new_version', type=str, required=False, helpmsg='New project version in a valid format.', cls=CustomArg)  # type: ignore
+@click.argument('project_dir', type=click.Path(), default=Path(f'{Path.cwd()}'),
+                helpmsg='Relative path to the projects directory.', cls=CustomArg)  # type: ignore
 @click.option('--downgrade', '-d', is_flag=True, help='Set this flag to downgrade a version.')
 @click.option('--project-version', is_flag=True, callback=print_project_version, expose_value=False, is_eager=True, help='Print your projects version and exit')
 @click.pass_context
@@ -281,7 +282,7 @@ def warp(input_dir: str, exec: str, output: str) -> None:
 
 @cookietemple_cli.command(short_help='Configure your general settings and github credentials.', cls=CustomHelpSubcommand)
 @click.option('--view', '-v', is_flag=True, help='View the current cookietemple configuration.')
-@click.argument('section', type=str, required=False, helpmsg='Section to configure (all, general or pat)', cls=CustomArg)
+@click.argument('section', type=str, required=False, helpmsg='Section to configure (all, general or pat)', cls=CustomArg)  # type: ignore
 @click.pass_context
 def config(ctx, view: bool, section: str) -> None:
     """

--- a/cookietemple/create/create.py
+++ b/cookietemple/create/create.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Union, Optional
+from pathlib import Path
 
 from cookietemple.create.domains.cli_creator import CliCreator
 from cookietemple.create.domains.web_creator import WebCreator
@@ -12,7 +13,7 @@ from cookietemple.custom_cli.questionary import cookietemple_questionary_or_dot_
 log = logging.getLogger(__name__)
 
 
-def choose_domain(domain: Union[str, bool], dot_cookietemple: Optional[dict]):
+def choose_domain(path: Path, domain: Union[str, bool], dot_cookietemple: Optional[dict]):
     """
     Prompts the user for the template domain.
     Creates the .cookietemple file.
@@ -38,4 +39,4 @@ def choose_domain(domain: Union[str, bool], dot_cookietemple: Optional[dict]):
     }
 
     creator_obj: Union[CliCreator, WebCreator, GuiCreator, LibCreator, PubCreator] = switcher.get(domain.lower())()  # type: ignore
-    creator_obj.create_template(dot_cookietemple)
+    creator_obj.create_template(path, dot_cookietemple)

--- a/cookietemple/create/create.py
+++ b/cookietemple/create/create.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Union, Optional
 
 from cookietemple.create.domains.cli_creator import CliCreator
 from cookietemple.create.domains.web_creator import WebCreator
@@ -11,7 +12,7 @@ from cookietemple.custom_cli.questionary import cookietemple_questionary_or_dot_
 log = logging.getLogger(__name__)
 
 
-def choose_domain(domain: str or None, dot_cookietemple: dict = None):
+def choose_domain(domain: Union[str, bool], dot_cookietemple: Optional[dict]):
     """
     Prompts the user for the template domain.
     Creates the .cookietemple file.
@@ -36,5 +37,5 @@ def choose_domain(domain: str or None, dot_cookietemple: dict = None):
         'pub': PubCreator
     }
 
-    creator_obj = switcher.get(domain.lower())()
+    creator_obj: Union[CliCreator, WebCreator, GuiCreator, LibCreator, PubCreator] = switcher.get(domain.lower())()  # type: ignore
     creator_obj.create_template(dot_cookietemple)

--- a/cookietemple/create/create.py
+++ b/cookietemple/create/create.py
@@ -1,5 +1,4 @@
 import logging
-from collections import OrderedDict
 
 from cookietemple.create.domains.cli_creator import CliCreator
 from cookietemple.create.domains.web_creator import WebCreator
@@ -12,7 +11,7 @@ from cookietemple.custom_cli.questionary import cookietemple_questionary_or_dot_
 log = logging.getLogger(__name__)
 
 
-def choose_domain(domain: str or None, dot_cookietemple: OrderedDict = None):
+def choose_domain(domain: str or None, dot_cookietemple: dict = None):
     """
     Prompts the user for the template domain.
     Creates the .cookietemple file.

--- a/cookietemple/create/domains/cli_creator.py
+++ b/cookietemple/create/domains/cli_creator.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 from dataclasses import dataclass
 from typing import Optional, Dict, Any
+from shutil import move
 
 from cookietemple.create.github_support import prompt_github_repo
 from cookietemple.create.template_creator import TemplateCreator
@@ -34,15 +35,14 @@ class CliCreator(TemplateCreator):
         self.WD_Path = Path(os.path.dirname(__file__))
         self.TEMPLATES_CLI_PATH = f'{self.WD_Path.parent}/templates/cli'
 
-        '"" TEMPLATE VERSIONS ""'
+        """ TEMPLATE VERSIONS """
         self.CLI_PYTHON_TEMPLATE_VERSION = load_ct_template_version('cli-python', self.AVAILABLE_TEMPLATES_PATH)
         self.CLI_JAVA_TEMPLATE_VERSION = load_ct_template_version('cli-java', self.AVAILABLE_TEMPLATES_PATH)
 
-    def create_template(self, dot_cookietemple: Optional[dict]):
+    def create_template(self, path: Path, dot_cookietemple: Optional[dict]):
         """
         Handles the CLI domain. Prompts the user for the language, general and domain specific options.
         """
-
         self.cli_struct.language = cookietemple_questionary_or_dot_cookietemple(function='select',
                                                                                 question='Choose the project\'s primary language',
                                                                                 choices=['python', 'java'],
@@ -81,9 +81,14 @@ class CliCreator(TemplateCreator):
 
         # perform general operations like creating a GitHub repository and general linting
         super().process_common_operations(domain='cli', language=self.cli_struct.language, dot_cookietemple=dot_cookietemple)
+        path = Path(path).resolve()
+        if path != Path.cwd():
+            move(f'{Path.cwd()}/{self.creator_ctx.project_slug_no_hyphen}', f'{path}/{self.creator_ctx.project_slug_no_hyphen}')
 
     def cli_python_options(self, dot_cookietemple: Optional[dict]):
-        """ Prompts for cli-python specific options and saves them into the CookietempleTemplateStruct """
+        """
+        Prompts for cli-python specific options and saves them into the CookietempleTemplateStruct
+        """
         self.cli_struct.command_line_interface = cookietemple_questionary_or_dot_cookietemple(function='select',
                                                                                               question='Choose a command line library',
                                                                                               choices=['Click', 'Argparse', 'No command-line interface'],

--- a/cookietemple/create/domains/cli_creator.py
+++ b/cookietemple/create/domains/cli_creator.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 from dataclasses import dataclass
 from typing import Optional, Dict, Any
-from shutil import move
 
 from cookietemple.create.github_support import prompt_github_repo
 from cookietemple.create.template_creator import TemplateCreator
@@ -80,10 +79,7 @@ class CliCreator(TemplateCreator):
             = switcher_version.get(self.cli_struct.language), f'cli-{self.cli_struct.language.lower()}'  # type: ignore
 
         # perform general operations like creating a GitHub repository and general linting
-        super().process_common_operations(domain='cli', language=self.cli_struct.language, dot_cookietemple=dot_cookietemple)
-        path = Path(path).resolve()
-        if path != Path.cwd():
-            move(f'{Path.cwd()}/{self.creator_ctx.project_slug_no_hyphen}', f'{path}/{self.creator_ctx.project_slug_no_hyphen}')
+        super().process_common_operations(path=Path(path).resolve(), domain='cli', language=self.cli_struct.language, dot_cookietemple=dot_cookietemple)
 
     def cli_python_options(self, dot_cookietemple: Optional[dict]):
         """

--- a/cookietemple/create/domains/cli_creator.py
+++ b/cookietemple/create/domains/cli_creator.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 from dataclasses import dataclass
+from typing import Optional, Dict, Any
 
 from cookietemple.create.github_support import prompt_github_repo
 from cookietemple.create.template_creator import TemplateCreator
@@ -37,7 +38,7 @@ class CliCreator(TemplateCreator):
         self.CLI_PYTHON_TEMPLATE_VERSION = load_ct_template_version('cli-python', self.AVAILABLE_TEMPLATES_PATH)
         self.CLI_JAVA_TEMPLATE_VERSION = load_ct_template_version('cli-java', self.AVAILABLE_TEMPLATES_PATH)
 
-    def create_template(self, dot_cookietemple: dict or None):
+    def create_template(self, dot_cookietemple: Optional[dict]):
         """
         Handles the CLI domain. Prompts the user for the language, general and domain specific options.
         """
@@ -53,11 +54,11 @@ class CliCreator(TemplateCreator):
         super().prompt_general_template_configuration(dot_cookietemple)
 
         # switch case statement to prompt the user to fetch template specific configurations
-        switcher = {
+        switcher: Dict[str, Any] = {
             'python': self.cli_python_options,
             'java': self.cli_java_options,
         }
-        switcher.get(self.cli_struct.language)(dot_cookietemple)
+        switcher.get(self.cli_struct.language)(dot_cookietemple)  # type: ignore
 
         self.cli_struct.is_github_repo, \
             self.cli_struct.is_repo_private, \
@@ -75,13 +76,13 @@ class CliCreator(TemplateCreator):
             'python': self.CLI_PYTHON_TEMPLATE_VERSION,
             'java': self.CLI_JAVA_TEMPLATE_VERSION
         }
-        self.cli_struct.template_version, self.cli_struct.template_handle = switcher_version.get(
-            self.cli_struct.language), f'cli-{self.cli_struct.language.lower()}'
+        self.cli_struct.template_version, self.cli_struct.template_handle\
+            = switcher_version.get(self.cli_struct.language), f'cli-{self.cli_struct.language.lower()}'  # type: ignore
 
         # perform general operations like creating a GitHub repository and general linting
         super().process_common_operations(domain='cli', language=self.cli_struct.language, dot_cookietemple=dot_cookietemple)
 
-    def cli_python_options(self, dot_cookietemple: dict or None):
+    def cli_python_options(self, dot_cookietemple: Optional[dict]):
         """ Prompts for cli-python specific options and saves them into the CookietempleTemplateStruct """
         self.cli_struct.command_line_interface = cookietemple_questionary_or_dot_cookietemple(function='select',
                                                                                               question='Choose a command line library',
@@ -96,7 +97,7 @@ class CliCreator(TemplateCreator):
                                                                                        dot_cookietemple=dot_cookietemple,
                                                                                        to_get_property='testing_library')
 
-    def cli_java_options(self, dot_cookietemple: dict or None) -> None:
+    def cli_java_options(self, dot_cookietemple: Optional[dict]) -> None:
         """ Prompts for cli-java specific options and saves them into the CookietempleTemplateStruct """
         self.cli_struct.group_domain = cookietemple_questionary_or_dot_cookietemple(function='text',
                                                                                     question='Domain (e.g. the org of org.apache)',

--- a/cookietemple/create/domains/cookietemple_template_struct.py
+++ b/cookietemple/create/domains/cookietemple_template_struct.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Union
 
 
 @dataclass
@@ -23,9 +24,9 @@ class CookietempleTemplateStruct:
     """
     This section contains some attributes common to cli, lib, gui, web
     """
-    full_name: str = ''  # Name of the template creator/organization
-    email: str = ''  # Email of the creator
-    project_name: str = ''  # Project's name the template is created for
-    project_short_description: str = ''  # A short description of the project
-    version: str = ''  # Version of the project; of the form: [0-9]*\.[0-9]*\.[0-9]*
-    license: str = ''  # License of the project
+    full_name: Union[str, bool] = ''  # Name of the template creator/organization
+    email: Union[str, bool] = ''  # Email of the creator
+    project_name: Union[str, bool] = ''  # Project's name the template is created for
+    project_short_description: Union[str, bool] = ''  # A short description of the project
+    version: Union[str, bool] = ''  # Version of the project; of the form: [0-9]*\.[0-9]*\.[0-9]*
+    license: Union[str, bool] = ''  # License of the project

--- a/cookietemple/create/domains/gui_creator.py
+++ b/cookietemple/create/domains/gui_creator.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 from dataclasses import dataclass
 from typing import Dict, Any, Optional
-from shutil import move
 
 from cookietemple.create.github_support import prompt_github_repo
 from cookietemple.create.template_creator import TemplateCreator
@@ -34,7 +33,7 @@ class GuiCreator(TemplateCreator):
     def create_template(self, path: Path, dot_cookietemple: Optional[Dict]):
         self.gui_struct.language = cookietemple_questionary_or_dot_cookietemple(function='select',
                                                                                 question='Choose between the following languages',
-                                                                                choices=['java', 'kotlin'],
+                                                                                choices=['java'],
                                                                                 dot_cookietemple=dot_cookietemple,
                                                                                 to_get_property='language')
 
@@ -64,10 +63,7 @@ class GuiCreator(TemplateCreator):
             = switcher_version.get(self.gui_struct.language.lower()), f'gui-{self.gui_struct.language.lower()}'  # type: ignore
 
         # perform general operations like creating a GitHub repository and general linting
-        super().process_common_operations(domain='gui', language=self.gui_struct.language, dot_cookietemple=dot_cookietemple)
-        path = Path(path).resolve()
-        if path != Path.cwd():
-            move(f'{Path.cwd()}/{self.creator_ctx.project_slug_no_hyphen}', f'{path}/{self.creator_ctx.project_slug_no_hyphen}')
+        super().process_common_operations(path=Path(path).resolve(), domain='gui', language=self.gui_struct.language, dot_cookietemple=dot_cookietemple)
 
     def gui_java_options(self, dot_cookietemple: Optional[Dict]) -> None:
         """

--- a/cookietemple/create/domains/gui_creator.py
+++ b/cookietemple/create/domains/gui_creator.py
@@ -1,7 +1,7 @@
 import os
-from collections import OrderedDict
 from pathlib import Path
 from dataclasses import dataclass
+from typing import Dict, Any, Optional
 
 from cookietemple.create.github_support import prompt_github_repo
 from cookietemple.create.template_creator import TemplateCreator
@@ -30,7 +30,7 @@ class GuiCreator(TemplateCreator):
         '"" TEMPLATE VERSIONS ""'
         self.GUI_JAVA_TEMPLATE_VERSION = load_ct_template_version('gui-java', self.AVAILABLE_TEMPLATES_PATH)
 
-    def create_template(self, dot_cookietemple: OrderedDict or None):
+    def create_template(self, dot_cookietemple: Optional[Dict]):
         self.gui_struct.language = cookietemple_questionary_or_dot_cookietemple(function='select',
                                                                                 question='Choose between the following languages',
                                                                                 choices=['java', 'kotlin'],
@@ -41,10 +41,10 @@ class GuiCreator(TemplateCreator):
         super().prompt_general_template_configuration(dot_cookietemple)
 
         # switch case statement to prompt the user to fetch template specific configurations
-        switcher = {
+        switcher: Dict[str, Any] = {
             'java': self.gui_java_options,
         }
-        switcher.get(self.gui_struct.language.lower())(dot_cookietemple)
+        switcher.get(self.gui_struct.language.lower())(dot_cookietemple)  # type: ignore
 
         self.gui_struct.is_github_repo, \
             self.gui_struct.is_repo_private, \
@@ -62,18 +62,18 @@ class GuiCreator(TemplateCreator):
             'java': self.GUI_JAVA_TEMPLATE_VERSION,
         }
 
-        self.gui_struct.template_version, self.gui_struct.template_handle = switcher_version.get(
-            self.gui_struct.language.lower()), f'gui-{self.gui_struct.language.lower()}'
+        self.gui_struct.template_version, self.gui_struct.template_handle\
+            = switcher_version.get(self.gui_struct.language.lower()), f'gui-{self.gui_struct.language.lower()}'  # type: ignore
 
         # perform general operations like creating a GitHub repository and general linting
         super().process_common_operations(domain='gui', language=self.gui_struct.language, dot_cookietemple=dot_cookietemple)
 
-    def gui_java_options(self, dot_cookietemple: OrderedDict or None) -> None:
+    def gui_java_options(self, dot_cookietemple: Optional[Dict]) -> None:
         """
         Prompt the user for all gui-java specific properties
         """
         # The user id is automatically determined from the full_name as first letter of first name and sur name
-        full_name_split = self.creator_ctx.full_name.split()
+        full_name_split = self.creator_ctx.full_name.split()  # type: ignore
         self.gui_struct.id = f'{full_name_split[0][0]}{full_name_split[1][0]}' if len(full_name_split) > 1 else f'{full_name_split[0][0]}'
         self.gui_struct.organization = cookietemple_questionary_or_dot_cookietemple(function='text',
                                                                                     question='Organization',

--- a/cookietemple/create/domains/lib_creator.py
+++ b/cookietemple/create/domains/lib_creator.py
@@ -1,4 +1,5 @@
 import os
+from shutil import move
 from pathlib import Path
 from dataclasses import dataclass
 from typing import Optional, Any, Dict
@@ -28,7 +29,7 @@ class LibCreator(TemplateCreator):
         '"" TEMPLATE VERSIONS ""'
         self.LIB_CPP_TEMPLATE_VERSION = load_ct_template_version('lib-cpp', self.AVAILABLE_TEMPLATES_PATH)
 
-    def create_template(self, dot_cookietemple: Optional[dict]):
+    def create_template(self, path: Path, dot_cookietemple: Optional[dict]):
         """
         Handles the LIB domain. Prompts the user for the language, general and domain specific options.
         """
@@ -69,6 +70,9 @@ class LibCreator(TemplateCreator):
 
         # perform general operations like creating a GitHub repository and general linting
         super().process_common_operations(domain='lib', language=self.lib_struct.language, dot_cookietemple=dot_cookietemple)
+        path = Path(path).resolve()
+        if path != Path.cwd():
+            move(f'{Path.cwd()}/{self.creator_ctx.project_slug_no_hyphen}', f'{path}/{self.creator_ctx.project_slug_no_hyphen}')
 
     def lib_cpp_options(self, dot_cookietemple: Optional[Dict]):
         """ Prompts for lib-cpp specific options and saves them into the CookietempleTemplateStruct """

--- a/cookietemple/create/domains/lib_creator.py
+++ b/cookietemple/create/domains/lib_creator.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 from dataclasses import dataclass
+from typing import Optional, Any, Dict
 
 from cookietemple.create.github_support import prompt_github_repo
 from cookietemple.create.template_creator import TemplateCreator
@@ -27,7 +28,7 @@ class LibCreator(TemplateCreator):
         '"" TEMPLATE VERSIONS ""'
         self.LIB_CPP_TEMPLATE_VERSION = load_ct_template_version('lib-cpp', self.AVAILABLE_TEMPLATES_PATH)
 
-    def create_template(self, dot_cookietemple: dict or None):
+    def create_template(self, dot_cookietemple: Optional[dict]):
         """
         Handles the LIB domain. Prompts the user for the language, general and domain specific options.
         """
@@ -43,10 +44,10 @@ class LibCreator(TemplateCreator):
         super().prompt_general_template_configuration(dot_cookietemple)
 
         # switch case statement to prompt the user to fetch template specific configurations
-        switcher = {
+        switcher: Dict[str, Any] = {
             'cpp': self.lib_cpp_options,
         }
-        switcher.get(self.lib_struct.language)(dot_cookietemple)
+        switcher.get(self.lib_struct.language)(dot_cookietemple)  # type: ignore
 
         self.lib_struct.is_github_repo, \
             self.lib_struct.is_repo_private, \
@@ -63,12 +64,12 @@ class LibCreator(TemplateCreator):
         switcher_version = {
             'cpp': self.LIB_CPP_TEMPLATE_VERSION,
         }
-        self.lib_struct.template_version, self.lib_struct.template_handle = switcher_version.get(
-            self.lib_struct.language), f'lib-{self.lib_struct.language.lower()}'
+        self.lib_struct.template_version, self.lib_struct.template_handle\
+            = switcher_version.get(self.lib_struct.language), f'lib-{self.lib_struct.language.lower()}'  # type: ignore
 
         # perform general operations like creating a GitHub repository and general linting
         super().process_common_operations(domain='lib', language=self.lib_struct.language, dot_cookietemple=dot_cookietemple)
 
-    def lib_cpp_options(self, dot_cookietemple: dict or None):
+    def lib_cpp_options(self, dot_cookietemple: Optional[Dict]):
         """ Prompts for lib-cpp specific options and saves them into the CookietempleTemplateStruct """
         pass

--- a/cookietemple/create/domains/lib_creator.py
+++ b/cookietemple/create/domains/lib_creator.py
@@ -1,5 +1,4 @@
 import os
-from shutil import move
 from pathlib import Path
 from dataclasses import dataclass
 from typing import Optional, Any, Dict
@@ -69,10 +68,7 @@ class LibCreator(TemplateCreator):
             = switcher_version.get(self.lib_struct.language), f'lib-{self.lib_struct.language.lower()}'  # type: ignore
 
         # perform general operations like creating a GitHub repository and general linting
-        super().process_common_operations(domain='lib', language=self.lib_struct.language, dot_cookietemple=dot_cookietemple)
-        path = Path(path).resolve()
-        if path != Path.cwd():
-            move(f'{Path.cwd()}/{self.creator_ctx.project_slug_no_hyphen}', f'{path}/{self.creator_ctx.project_slug_no_hyphen}')
+        super().process_common_operations(path=Path(path).resolve(), domain='lib', language=self.lib_struct.language, dot_cookietemple=dot_cookietemple)
 
     def lib_cpp_options(self, dot_cookietemple: Optional[Dict]):
         """ Prompts for lib-cpp specific options and saves them into the CookietempleTemplateStruct """

--- a/cookietemple/create/domains/pub_creator.py
+++ b/cookietemple/create/domains/pub_creator.py
@@ -1,9 +1,8 @@
 import os
-
+from shutil import move
 from pathlib import Path
 from dataclasses import dataclass
 from typing import Optional, Any, Dict
-
 from rich import print
 
 from cookietemple.create.template_creator import TemplateCreator
@@ -43,7 +42,7 @@ class PubCreator(TemplateCreator):
         '"" TEMPLATE VERSIONS ""'
         self.PUB_LATEX_TEMPLATE_VERSION = load_ct_template_version('pub-thesis-latex', self.AVAILABLE_TEMPLATES_PATH)
 
-    def create_template(self, dot_cookietemple: Optional[dict]):
+    def create_template(self, path: Path, dot_cookietemple: Optional[dict]):
         """
         Prompts the user for the publication type and forwards to subsequent prompts.
         Creates the pub template.
@@ -69,10 +68,7 @@ class PubCreator(TemplateCreator):
 
         self.handle_pub_type(dot_cookietemple)
 
-        self.pub_struct.is_github_repo, \
-            self.pub_struct.is_repo_private, \
-            self.pub_struct.is_github_orga, \
-            self.pub_struct.github_orga \
+        self.pub_struct.is_github_repo, self.pub_struct.is_repo_private, self.pub_struct.is_github_orga, self.pub_struct.github_orga \
             = prompt_github_repo(dot_cookietemple)
 
         if self.pub_struct.is_github_orga:
@@ -93,6 +89,9 @@ class PubCreator(TemplateCreator):
         super().process_common_operations(skip_common_files=True, skip_fix_underline=True,
                                           domain='pub', subdomain=self.pub_struct.pubtype, language=self.pub_struct.language,
                                           dot_cookietemple=dot_cookietemple)
+        path = Path(path).resolve()
+        if path != Path.cwd():
+            move(f'{Path.cwd()}/{self.creator_ctx.project_slug_no_hyphen}', f'{path}/{self.creator_ctx.project_slug_no_hyphen}')
 
     def handle_pub_type(self, dot_cookietemple: Optional[dict]) -> None:
         """

--- a/cookietemple/create/domains/pub_creator.py
+++ b/cookietemple/create/domains/pub_creator.py
@@ -1,8 +1,9 @@
 import os
-from collections import OrderedDict
 
 from pathlib import Path
 from dataclasses import dataclass
+from typing import Optional, Any, Dict
+
 from rich import print
 
 from cookietemple.create.template_creator import TemplateCreator
@@ -42,7 +43,7 @@ class PubCreator(TemplateCreator):
         '"" TEMPLATE VERSIONS ""'
         self.PUB_LATEX_TEMPLATE_VERSION = load_ct_template_version('pub-thesis-latex', self.AVAILABLE_TEMPLATES_PATH)
 
-    def create_template(self, dot_cookietemple: OrderedDict or None):
+    def create_template(self, dot_cookietemple: Optional[dict]):
         """
         Prompts the user for the publication type and forwards to subsequent prompts.
         Creates the pub template.
@@ -61,10 +62,10 @@ class PubCreator(TemplateCreator):
             ConfigCommand.all_settings()
 
         # switch case statement to prompt the user to fetch template specific configurations
-        switcher = {
+        switcher: Dict[str, Any] = {
             'latex': self.common_latex_options,
         }
-        switcher.get(self.pub_struct.language.lower(), lambda: 'Invalid language!')(dot_cookietemple)
+        switcher.get(self.pub_struct.language.lower(), lambda: 'Invalid language!')(dot_cookietemple)  # type: ignore
 
         self.handle_pub_type(dot_cookietemple)
 
@@ -77,7 +78,7 @@ class PubCreator(TemplateCreator):
         if self.pub_struct.is_github_orga:
             self.pub_struct.github_username = self.pub_struct.github_orga
         # create the pub template
-        super().create_template_with_subdomain(self.TEMPLATES_PUB_PATH, self.pub_struct.pubtype)
+        super().create_template_with_subdomain(self.TEMPLATES_PUB_PATH, self.pub_struct.pubtype)  # type: ignore
 
         # switch case statement to fetch the template version
         switcher_version = {
@@ -93,8 +94,7 @@ class PubCreator(TemplateCreator):
                                           domain='pub', subdomain=self.pub_struct.pubtype, language=self.pub_struct.language,
                                           dot_cookietemple=dot_cookietemple)
 
-    # TODO: IMPLEMENT BELOW
-    def handle_pub_type(self, dot_cookietemple: dict or None) -> None:
+    def handle_pub_type(self, dot_cookietemple: Optional[dict]) -> None:
         """
         Determine the type of publication and handle it further.
         """
@@ -102,16 +102,16 @@ class PubCreator(TemplateCreator):
         switcher = {
             'thesis': self.handle_thesis_latex,
         }
-        switcher.get(self.pub_struct.pubtype.lower(), lambda: 'Invalid Pub Project Type!')(dot_cookietemple)
+        switcher.get(self.pub_struct.pubtype.lower(), lambda: 'Invalid Pub Project Type!')(dot_cookietemple)  # type: ignore
 
-    def handle_thesis_latex(self, dot_cookietemple: dict or None) -> None:
+    def handle_thesis_latex(self, dot_cookietemple: Optional[dict]) -> None:
         self.pub_struct.degree = cookietemple_questionary_or_dot_cookietemple(function='text',
                                                                               question='Degree',
                                                                               default='PhD',
                                                                               dot_cookietemple=dot_cookietemple,
                                                                               to_get_property='degree')
 
-    def common_latex_options(self, dot_cookietemple: dict or None) -> None:
+    def common_latex_options(self, dot_cookietemple: Optional[dict]) -> None:
         """
         Prompt the user for common thesis/paper data
         """
@@ -125,7 +125,7 @@ class PubCreator(TemplateCreator):
                                                                                     default='PhD Thesis',
                                                                                     dot_cookietemple=dot_cookietemple,
                                                                                     to_get_property='project_name')
-        self.pub_struct.project_slug = self.pub_struct.project_name.replace(' ', '_').replace('-', '_')
+        self.pub_struct.project_slug = self.pub_struct.project_name.replace(' ', '_').replace('-', '_')  # type: ignore
         self.pub_struct.title = cookietemple_questionary_or_dot_cookietemple(function='text',
                                                                              question='Publication title',
                                                                              default='On how Springfield exploded',

--- a/cookietemple/create/domains/pub_creator.py
+++ b/cookietemple/create/domains/pub_creator.py
@@ -1,5 +1,4 @@
 import os
-from shutil import move
 from pathlib import Path
 from dataclasses import dataclass
 from typing import Optional, Any, Dict
@@ -86,12 +85,9 @@ class PubCreator(TemplateCreator):
             self.pub_struct.language.lower(), lambda: 'Invalid language!'), f'pub-{self.pub_struct.pubtype}-{self.pub_struct.language.lower()}'
 
         # perform general operations like creating a GitHub repository and general linting, but skip common_files copying and rst linting
-        super().process_common_operations(skip_common_files=True, skip_fix_underline=True,
+        super().process_common_operations(path=Path(path).resolve(), skip_common_files=True, skip_fix_underline=True,
                                           domain='pub', subdomain=self.pub_struct.pubtype, language=self.pub_struct.language,
                                           dot_cookietemple=dot_cookietemple)
-        path = Path(path).resolve()
-        if path != Path.cwd():
-            move(f'{Path.cwd()}/{self.creator_ctx.project_slug_no_hyphen}', f'{path}/{self.creator_ctx.project_slug_no_hyphen}')
 
     def handle_pub_type(self, dot_cookietemple: Optional[dict]) -> None:
         """

--- a/cookietemple/create/domains/web_creator.py
+++ b/cookietemple/create/domains/web_creator.py
@@ -1,5 +1,4 @@
 import os
-from shutil import move
 from pathlib import Path
 from dataclasses import dataclass
 from distutils.dir_util import copy_tree
@@ -102,13 +101,10 @@ class WebCreator(TemplateCreator):
             = switcher_version.get(self.web_struct.language), f'web-{self.web_struct.webtype}-{self.web_struct.language.lower()}'  # type: ignore
 
         # perform general operations like creating a GitHub repository and general linting
-        super().process_common_operations(domain='web',
+        super().process_common_operations(path=Path(path).resolve(), domain='web',
                                           subdomain=self.web_struct.webtype,
                                           language=self.web_struct.language,
                                           dot_cookietemple=dot_cookietemple)
-        path = Path(path).resolve()
-        if path != Path.cwd():
-            move(f'{Path.cwd()}/{self.creator_ctx.project_slug_no_hyphen}', f'{path}/{self.creator_ctx.project_slug_no_hyphen}')
 
     def handle_web_project_type_python(self, dot_cookietemple: Optional[dict]) -> None:
         """

--- a/cookietemple/create/domains/web_creator.py
+++ b/cookietemple/create/domains/web_creator.py
@@ -1,10 +1,11 @@
 import os
-from collections import OrderedDict
 
 from pathlib import Path
 from dataclasses import dataclass
 from distutils.dir_util import copy_tree
 from shutil import copy
+from typing import Optional, Any, Dict
+
 from rich import print
 
 from cookietemple.create.template_creator import TemplateCreator
@@ -55,7 +56,7 @@ class WebCreator(TemplateCreator):
         '""Web Template Versions""'
         self.WEB_WEBSITE_PYTHON_TEMPLATE_VERSION = load_ct_template_version('web-website-python', self.AVAILABLE_TEMPLATES_PATH)
 
-    def create_template(self, dot_cookietemple: dict or None) -> None:
+    def create_template(self, dot_cookietemple: Optional[dict]) -> None:
         """
         Handles the Web domain. Prompts the user for the language, general and domain specific options.
         """
@@ -70,10 +71,10 @@ class WebCreator(TemplateCreator):
         super().prompt_general_template_configuration(dot_cookietemple)
 
         # switch case statement to prompt the user to fetch template specific configurations
-        switcher = {
+        switcher: Dict[str, Any] = {
             'python': self.web_python_options,
         }
-        switcher.get(self.web_struct.language)(dot_cookietemple)
+        switcher.get(self.web_struct.language)(dot_cookietemple)  # type: ignore
         # call handle function for specified language
         self.__getattribute__(f'handle_web_project_type_{self.web_struct.language}')(dot_cookietemple)
         # call handle function for specified webtype according to the chosen language
@@ -98,8 +99,8 @@ class WebCreator(TemplateCreator):
             'python': self.WEB_WEBSITE_PYTHON_TEMPLATE_VERSION
         }
 
-        self.web_struct.template_version, self.web_struct.template_handle = switcher_version.get(
-            self.web_struct.language), f'web-{self.web_struct.webtype}-{self.web_struct.language.lower()}'
+        self.web_struct.template_version, self.web_struct.template_handle\
+            = switcher_version.get(self.web_struct.language), f'web-{self.web_struct.webtype}-{self.web_struct.language.lower()}'  # type: ignore
 
         # perform general operations like creating a GitHub repository and general linting
         super().process_common_operations(domain='web',
@@ -107,7 +108,7 @@ class WebCreator(TemplateCreator):
                                           language=self.web_struct.language,
                                           dot_cookietemple=dot_cookietemple)
 
-    def handle_web_project_type_python(self, dot_cookietemple: dict or None) -> None:
+    def handle_web_project_type_python(self, dot_cookietemple: Optional[dict]) -> None:
         """
         Determine the type of web application
         """
@@ -118,7 +119,7 @@ class WebCreator(TemplateCreator):
                                                                                dot_cookietemple=dot_cookietemple,
                                                                                to_get_property='webtype')
 
-    def handle_website_python(self, dot_cookietemple: dict or None) -> None:
+    def handle_website_python(self, dot_cookietemple: Optional[dict]) -> None:
         """
         Handle the website template creation. The user can choose between a basic website setup and a more advanced
         with database support, mail, translation, cli commands for translation, login and register function.
@@ -151,7 +152,7 @@ class WebCreator(TemplateCreator):
             # strings that start with https: are recognized by most terminal (emulators) as links
             print('[bold blue]https://html5up.net/solid-state')
 
-            self.web_struct.frontend = cookietemple_questionary_or_dot_cookietemple(function='select',
+            self.web_struct.frontend = cookietemple_questionary_or_dot_cookietemple(function='select',  # type: ignore
                                                                                     question='Choose between the following predefined frontend templates',
                                                                                     choices=['SolidState', 'None'],
                                                                                     dot_cookietemple=dot_cookietemple,
@@ -163,7 +164,7 @@ class WebCreator(TemplateCreator):
                                                                            dot_cookietemple=dot_cookietemple,
                                                                            to_get_property='url')
 
-    def website_flask_options(self, dot_cookietemple: OrderedDict or None) -> None:
+    def website_flask_options(self, dot_cookietemple: Optional[dict]) -> None:
         """
         Prompt for flask template options
         """
@@ -231,7 +232,7 @@ class WebCreator(TemplateCreator):
 
         os.chdir(cwd)
 
-    def web_python_options(self, dot_cookietemple: OrderedDict or None):
+    def web_python_options(self, dot_cookietemple: Optional[dict]):
         """ Prompts for web-python specific options and saves them into the CookietempleTemplateStruct """
         self.web_struct.command_line_interface = cookietemple_questionary_or_dot_cookietemple(function='select',
                                                                                               question='Choose a command line library',

--- a/cookietemple/create/domains/web_creator.py
+++ b/cookietemple/create/domains/web_creator.py
@@ -1,11 +1,10 @@
 import os
-
+from shutil import move
 from pathlib import Path
 from dataclasses import dataclass
 from distutils.dir_util import copy_tree
 from shutil import copy
 from typing import Optional, Any, Dict
-
 from rich import print
 
 from cookietemple.create.template_creator import TemplateCreator
@@ -56,7 +55,7 @@ class WebCreator(TemplateCreator):
         '""Web Template Versions""'
         self.WEB_WEBSITE_PYTHON_TEMPLATE_VERSION = load_ct_template_version('web-website-python', self.AVAILABLE_TEMPLATES_PATH)
 
-    def create_template(self, dot_cookietemple: Optional[dict]) -> None:
+    def create_template(self, path: Path, dot_cookietemple: Optional[dict]) -> None:
         """
         Handles the Web domain. Prompts the user for the language, general and domain specific options.
         """
@@ -107,6 +106,9 @@ class WebCreator(TemplateCreator):
                                           subdomain=self.web_struct.webtype,
                                           language=self.web_struct.language,
                                           dot_cookietemple=dot_cookietemple)
+        path = Path(path).resolve()
+        if path != Path.cwd():
+            move(f'{Path.cwd()}/{self.creator_ctx.project_slug_no_hyphen}', f'{path}/{self.creator_ctx.project_slug_no_hyphen}')
 
     def handle_web_project_type_python(self, dot_cookietemple: Optional[dict]) -> None:
         """

--- a/cookietemple/create/github_support.py
+++ b/cookietemple/create/github_support.py
@@ -104,7 +104,7 @@ def create_push_github_repository(project_path: str, creator_ctx: CookietempleTe
             master_branch = authenticated_github_user.get_user().get_repo(name=creator_ctx.project_slug).get_branch("master")
             master_branch.edit_protection(dismiss_stale_reviews=True)
         else:
-            print('[bold blue]Cannot set branch protection rules due to your repository being private or an orga repo!\n'
+            print('[bold blue]Cannot set branch protection rules due to your repository being private or an organization repo!\n'
                   'You can set them manually later on.')
 
         # git create development branch

--- a/cookietemple/create/github_support.py
+++ b/cookietemple/create/github_support.py
@@ -94,15 +94,24 @@ def create_push_github_repository(project_path: str, creator_ctx: CookietempleTe
         cloned_repo.index.commit(f'Created {creator_ctx.project_slug} with {creator_ctx.template_handle} '
                                  f'template of version {creator_ctx.template_version.replace("# <<COOKIETEMPLE_NO_BUMP>>", "")} using cookietemple.')
 
-        log.debug('git push origin master')
-        print('[bold blue]Pushing template to Github origin master')
-        cloned_repo.remotes.origin.push(refspec='master:master')
+        # get the default branch of the repository as default branch of GitHub repositories are nor configurable by the user and can be set to any branch name
+        # but cookietemple needs to know which one is the default branch in order to push to the correct remote branch and rename local branch, if necessary
+        headers = {'Authorization': f'token {access_token}'}
+        url = f"https://api.github.com/repos/{creator_ctx.github_username}/{creator_ctx.project_slug}"
+        response = requests.get(url, headers=headers).json()
+        default_branch = response['default_branch']
+        log.debug(f'git push origin {default_branch}')
+        print(f'[bold blue]Pushing template to Github origin {default_branch}')
+        if default_branch != 'master':
+            cloned_repo.git.branch('-M', f'{default_branch}')
+        cloned_repo.remotes.origin.push(refspec=f'{default_branch}:{default_branch}')
 
         # set branch protection (all WF must pass, dismiss stale PR reviews) only when repo is public
         log.debug('Set branch protection rules.')
+
         if not creator_ctx.is_repo_private and not creator_ctx.is_github_orga:
-            master_branch = authenticated_github_user.get_user().get_repo(name=creator_ctx.project_slug).get_branch("master")
-            master_branch.edit_protection(dismiss_stale_reviews=True)
+            main_branch = authenticated_github_user.get_user().get_repo(name=creator_ctx.project_slug).get_branch(f'{default_branch}')
+            main_branch.edit_protection(dismiss_stale_reviews=True)
         else:
             print('[bold blue]Cannot set branch protection rules due to your repository being private or an organization repo!\n'
                   'You can set them manually later on.')

--- a/cookietemple/create/github_support.py
+++ b/cookietemple/create/github_support.py
@@ -1,19 +1,20 @@
 import logging
 import os
 import sys
+from typing import Union, Tuple, Optional
+
 import requests
 import json
 from base64 import b64encode
-from nacl import encoding, public
+from nacl import encoding, public  # type: ignore
 from pathlib import Path
 from cryptography.fernet import Fernet
 from distutils.dir_util import copy_tree
 from subprocess import Popen, PIPE
 from github import Github, GithubException
-from git import Repo, exc
+from git import Repo, exc  # type: ignore
 from ruamel.yaml import YAML
 from rich import print
-from collections import OrderedDict
 
 from cookietemple.create.domains.cookietemple_template_struct import CookietempleTemplateStruct
 from cookietemple.custom_cli.questionary import cookietemple_questionary_or_dot_cookietemple
@@ -50,11 +51,15 @@ def create_push_github_repository(project_path: str, creator_ctx: CookietempleTe
         if creator_ctx.is_github_orga:
             log.debug(f'Creating a new Github repository for organizaton: {creator_ctx.github_orga}.')
             org = authenticated_github_user.get_organization(creator_ctx.github_orga)
-            repo = org.create_repo(creator_ctx.project_slug, description=creator_ctx.project_short_description, private=creator_ctx.is_repo_private)
+            repo = org.create_repo(creator_ctx.project_slug,
+                                   description=creator_ctx.project_short_description,  # type: ignore
+                                   private=creator_ctx.is_repo_private)
             creator_ctx.github_username = creator_ctx.github_orga
         else:
             log.debug(f'Creating a new Github repository for user: {creator_ctx.github_username}.')
-            repo = user.create_repo(creator_ctx.project_slug, description=creator_ctx.project_short_description, private=creator_ctx.is_repo_private)
+            repo = user.create_repo(creator_ctx.project_slug,
+                                    description=creator_ctx.project_short_description,  # type: ignore
+                                    private=creator_ctx.is_repo_private)
 
         print('[bold blue]Creating labels and default Github settings')
         create_github_labels(repo=repo, labels=[('DEPENDABOT', '1BB0CE')])
@@ -170,8 +175,10 @@ def handle_pat_authentification() -> str:
     else:
         print('[bold red]Cannot find a cookietemple config file! Did you delete it?')
 
+    return ''
 
-def prompt_github_repo(dot_cookietemple: OrderedDict or None) -> (bool, bool, bool, str):
+
+def prompt_github_repo(dot_cookietemple: Optional[dict]) -> Tuple[bool, bool, bool, str]:
     """
     Ask user for all settings needed in order to create and push automatically to GitHub repo.
 
@@ -195,20 +202,20 @@ def prompt_github_repo(dot_cookietemple: OrderedDict or None) -> (bool, bool, bo
                                                     question='Do you want to create a Github repository and push your template to it?',
                                                     default='Yes'):
         create_git_repo = True
-        is_github_org = cookietemple_questionary_or_dot_cookietemple(function='confirm',
+        is_github_org = cookietemple_questionary_or_dot_cookietemple(function='confirm',  # type: ignore
                                                                      question='Do you want to create an organization repository?',
                                                                      default='No')
-        github_org = cookietemple_questionary_or_dot_cookietemple(function='text',
+        github_org = cookietemple_questionary_or_dot_cookietemple(function='text',  # type: ignore
                                                                   question='Please enter the name of the Github organization',
                                                                   default='SpringfieldNuclearPowerPlant') if is_github_org else ''
-        private = cookietemple_questionary_or_dot_cookietemple(function='confirm',
+        private = cookietemple_questionary_or_dot_cookietemple(function='confirm',  # type: ignore
                                                                question='Do you want your repository to be private?',
                                                                default='No')
 
     return create_git_repo, private, is_github_org, github_org
 
 
-def create_sync_secret(username: str, repo_name: str, token: str) -> None:
+def create_sync_secret(username: str, repo_name: str, token: Union[str, bool]) -> None:
     """
     Create the secret cookietemple uses to sync repos. The secret contains the personal access token with the repo scope.
     Following steps are required (PAT MUST have at least repo access):
@@ -225,7 +232,7 @@ def create_sync_secret(username: str, repo_name: str, token: str) -> None:
     create_secret(username, repo_name, token, public_key_dict['key'], public_key_dict['key_id'])
 
 
-def get_repo_public_key(username: str, repo_name: str, token: str) -> dict:
+def get_repo_public_key(username: str, repo_name: str, token: Union[str, bool]) -> dict:
     """
     Get the public key for a repository via the Github API. At least for private repos, a personal access token (PAT) with the repo scope is required.
 
@@ -241,7 +248,7 @@ def get_repo_public_key(username: str, repo_name: str, token: str) -> dict:
     return r.json()
 
 
-def create_secret(username: str, repo_name: str, token: str, public_key_value: str, public_key_id: str) -> None:
+def create_secret(username: str, repo_name: str, token: Union[str, bool], public_key_value: str, public_key_id: str) -> None:
     """
     Create the secret named CT_SYNC_TOKEN using a PUT request via the Github API. This request needs a PAT with the repo scope for authentification purposes.
     Using PyNacl, a Python binding for Javascripts LibSodium, it encrypts the secret value, which is required by the Github API.
@@ -266,7 +273,7 @@ def create_secret(username: str, repo_name: str, token: str, public_key_value: s
     requests.put(put_url, headers=headers, data=json.dumps(params))
 
 
-def encrypt_sync_secret(public_key: str, token: str) -> str:
+def encrypt_sync_secret(public_key: str, token: Union[str, bool]) -> str:
     """
     Encrypt the sync secret (which is the PAT).
 
@@ -278,7 +285,7 @@ def encrypt_sync_secret(public_key: str, token: str) -> str:
     log.debug('Encrypting Github repository secret.')
     public_key = public.PublicKey(public_key.encode("utf-8"), encoding.Base64Encoder())
     sealed_box = public.SealedBox(public_key)
-    encrypted = sealed_box.encrypt(token.encode("utf-8"))
+    encrypted = sealed_box.encrypt(token.encode("utf-8"))  # type: ignore
 
     return b64encode(encrypted).decode("utf-8")
 
@@ -313,7 +320,7 @@ def load_github_username() -> str:
     return load_yaml_file(ConfigCommand.CONF_FILE_PATH)['github_username']
 
 
-def handle_failed_github_repo_creation(e: ConnectionError or GithubException) -> None:
+def handle_failed_github_repo_creation(e: Union[ConnectionError, GithubException]) -> None:
     """
     Called, when the automatic GitHub repo creation process failed during the create process. As this may have various issue sources,
     try to provide the user a detailed error message for the individual exception and inform them about what they should/can do next.
@@ -340,7 +347,8 @@ def format_github_exception(data: dict) -> None:
             print(f'[bold red]{section.capitalize()}: {description}')
         else:
             print(f'[bold red]{section.upper()}: ')
-            messages = [val if not isinstance(val, dict) and not isinstance(val, set) else github_exception_dict_repr(val) for val in description]
+            messages = [val if not isinstance(val, dict) and not isinstance(val, set)
+                        else github_exception_dict_repr(val) for val in description]  # type: ignore
             print('[bold red]\n'.join(msg for msg in messages))
 
 

--- a/cookietemple/create/template_creator.py
+++ b/cookietemple/create/template_creator.py
@@ -1,12 +1,10 @@
 import logging
 import os
 import sys
-
 import shutil
 import re
 import tempfile
 from typing import Optional, Union
-
 import cookietemple
 import requests
 from distutils.dir_util import copy_tree
@@ -44,7 +42,7 @@ class TemplateCreator:
         self.CWD = os.getcwd()
         self.creator_ctx = creator_ctx
 
-    def process_common_operations(self, skip_common_files=False, skip_fix_underline=False,
+    def process_common_operations(self, path: Path, skip_common_files=False, skip_fix_underline=False,
                                   domain: Optional[str] = None, subdomain: Union[str, bool] = None, language: Union[str, bool] = None,
                                   dot_cookietemple: Optional[dict] = None) -> None:
         """
@@ -85,6 +83,9 @@ class TemplateCreator:
             print()
             print('[bold blue]Please visit: https://cookietemple.readthedocs.io/en/latest/available_templates/available_templates.html'
                   f'#{domain}-{language} for more information about how to use your chosen template.')
+
+        if path != Path.cwd():
+            shutil.move(f'{Path.cwd()}/{self.creator_ctx.project_slug_no_hyphen}', f'{path}/{self.creator_ctx.project_slug_no_hyphen}')
 
     def create_template_without_subdomain(self, domain_path: str) -> None:
         """

--- a/cookietemple/create/template_creator.py
+++ b/cookietemple/create/template_creator.py
@@ -177,7 +177,13 @@ class TemplateCreator:
         Options are saved in the creator context manager object.
         """
         try:
-            # try to read name and email from existing config file
+            """
+            Check, if the dot_cookietemple dictionary contains the full name and email (this happens, when dry creating the template while syncing on
+            TEMPLATE branch).
+            If that's not the case, try to read them from the config file (created with the config command).
+
+            If none of the approaches above succeed (no config file has been found and its not a dry create run), configure the basic credentials and proceed.
+            """
             if dot_cookietemple:
                 self.creator_ctx.full_name = dot_cookietemple['full_name']
                 self.creator_ctx.email = dot_cookietemple['email']

--- a/cookietemple/create/template_creator.py
+++ b/cookietemple/create/template_creator.py
@@ -1,11 +1,11 @@
 import logging
 import os
 import sys
-from collections import OrderedDict
 
 import shutil
 import re
 import tempfile
+from typing import Optional, Union
 
 import cookietemple
 import requests
@@ -13,7 +13,7 @@ from distutils.dir_util import copy_tree
 from pathlib import Path
 from dataclasses import asdict
 from ruamel.yaml import YAML
-from cookiecutter.main import cookiecutter
+from cookiecutter.main import cookiecutter  # type: ignore
 
 from cookietemple.custom_cli.questionary import cookietemple_questionary_or_dot_cookietemple
 from cookietemple.util.dir_util import delete_dir_tree
@@ -45,8 +45,8 @@ class TemplateCreator:
         self.creator_ctx = creator_ctx
 
     def process_common_operations(self, skip_common_files=False, skip_fix_underline=False,
-                                  domain: str = None, subdomain: str = None, language: str = None,
-                                  dot_cookietemple: OrderedDict = None) -> None:
+                                  domain: Optional[str] = None, subdomain: Union[str, bool] = None, language: Union[str, bool] = None,
+                                  dot_cookietemple: Optional[dict] = None) -> None:
         """
         Create all stuff that is common for cookietemples template creation process; in detail those things are:
         create and copy common files, fix docs style, lint the project and ask whether the user wants to create a github repo.
@@ -171,7 +171,7 @@ class TemplateCreator:
                          overwrite_if_exists=True,
                          extra_context=self.creator_ctx_to_dict())
 
-    def prompt_general_template_configuration(self, dot_cookietemple: OrderedDict):
+    def prompt_general_template_configuration(self, dot_cookietemple: Optional[dict]):
         """
         Prompts the user for general options that are required by all templates.
         Options are saved in the creator context manager object.
@@ -212,7 +212,7 @@ class TemplateCreator:
         if self.creator_ctx.language == 'python':
             self.check_name_available("PyPi", dot_cookietemple)
         self.check_name_available("readthedocs.io", dot_cookietemple)
-        self.creator_ctx.project_slug = self.creator_ctx.project_name.replace(' ', '_')
+        self.creator_ctx.project_slug = self.creator_ctx.project_name.replace(' ', '_')  # type: ignore
         self.creator_ctx.project_slug_no_hyphen = self.creator_ctx.project_slug.replace('-', '_')
         self.creator_ctx.project_short_description = cookietemple_questionary_or_dot_cookietemple(function='text',
                                                                                                   question='Short description of your project',
@@ -227,7 +227,7 @@ class TemplateCreator:
                                                                  to_get_property='version')
 
         # make sure that the version has the right format
-        while not re.match(r'(?<!.)\d+(?:\.\d+){2}(?:-SNAPSHOT)?(?!.)', poss_vers) and not dot_cookietemple:
+        while not re.match(r'(?<!.)\d+(?:\.\d+){2}(?:-SNAPSHOT)?(?!.)', poss_vers) and not dot_cookietemple:  # type: ignore
             print('[bold red]The version number entered does not match semantic versioning.\n' +
                   'Please enter the version in the format \[number].\[number].\[number]!')  # noqa: W605
             poss_vers = cookietemple_questionary_or_dot_cookietemple(function='text',
@@ -295,7 +295,7 @@ class TemplateCreator:
         Main function that calls the queries for the project name lookup at PyPi and readthedocs.io
         """
         # if project already exists at either PyPi or readthedocs, ask user for confirmation with the option to change the project name
-        while TemplateCreator.query_name_available(host, self.creator_ctx.project_name) and not dot_cookietemple:
+        while TemplateCreator.query_name_available(host, self.creator_ctx.project_name) and not dot_cookietemple:  # type: ignore
             print(f'[bold red]A project named {self.creator_ctx.project_name} already exists at {host}!')
             # provide the user an option to change the project's name
             if cookietemple_questionary_or_dot_cookietemple(function='confirm',
@@ -336,6 +336,8 @@ class TemplateCreator:
             log.debug(f'Error was: {e}')
             print(f'[bold red]Cannot check whether name already taken on {host} because its unreachable at the moment!')
             return False
+
+        return False
 
     def directory_exists_warning(self) -> None:
         """

--- a/cookietemple/create/templates/cli/cli_java/{{ cookiecutter.project_slug }}/.github/workflows/build_deploy.yml
+++ b/cookietemple/create/templates/cli/cli_java/{{ cookiecutter.project_slug }}/.github/workflows/build_deploy.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: DeLaGuardo/setup-graalvm@2.0
+    - uses: eLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
       with:
         graalvm-version: '20.1.0.java11'
     - run: java -version
@@ -39,9 +39,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - uses: DeLaGuardo/setup-graalvm@2.0
+      - uses: eLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
         with:
-          graalvm-version: '19.3.0.2.java11'
+          graalvm-version: '20.1.0.java11'
       - run: java -version
       - name: Set up Visual C Build Tools Workload for Visual Studio 2017 Build Tools
         run: |

--- a/cookietemple/create/templates/cli/cli_java/{{ cookiecutter.project_slug }}/.github/workflows/build_deploy.yml
+++ b/cookietemple/create/templates/cli/cli_java/{{ cookiecutter.project_slug }}/.github/workflows/build_deploy.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: eLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
+    - uses: DeLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
       with:
         graalvm-version: '20.1.0.java11'
     - run: java -version
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - uses: eLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
+      - uses: DeLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
         with:
           graalvm-version: '20.1.0.java11'
       - run: java -version

--- a/cookietemple/create/templates/cli/cli_java/{{ cookiecutter.project_slug }}/.github/workflows/run_tests.yml
+++ b/cookietemple/create/templates/cli/cli_java/{{ cookiecutter.project_slug }}/.github/workflows/run_tests.yml
@@ -1,6 +1,6 @@
 name: Run Tests
 
-on: 
+on:
   push:
     paths-ignore:
       - "docs/**"
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: DeLaGuardo/setup-graalvm@2.0
+    - uses: eLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
       with:
         graalvm-version: '20.1.0.java11'
     - run: java -version
@@ -33,9 +33,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - uses: DeLaGuardo/setup-graalvm@2.0
+      - uses: eLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
         with:
-          graalvm-version: '19.3.0.2.java11'
+          graalvm-version: '20.1.0.java11'
       - run: java -version
       - name: Set up Visual C Build Tools Workload for Visual Studio 2017 Build Tools
         run: |

--- a/cookietemple/create/templates/cli/cli_java/{{ cookiecutter.project_slug }}/.github/workflows/run_tests.yml
+++ b/cookietemple/create/templates/cli/cli_java/{{ cookiecutter.project_slug }}/.github/workflows/run_tests.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: eLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
+    - uses: DeLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
       with:
         graalvm-version: '20.1.0.java11'
     - run: java -version
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - uses: eLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
+      - uses: DeLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
         with:
           graalvm-version: '20.1.0.java11'
       - run: java -version

--- a/cookietemple/create/templates/cli/cli_java/{{ cookiecutter.project_slug }}/cookietemple.cfg
+++ b/cookietemple/create/templates/cli/cli_java/{{ cookiecutter.project_slug }}/cookietemple.cfg
@@ -12,4 +12,5 @@ build_gradle = build.gradle
 ct_sync_level = minor
 
 [sync_files_blacklisted]
+changelog = CHANGELOG.rst
 

--- a/cookietemple/create/templates/cli/cli_python/{{ cookiecutter.project_slug_no_hyphen }}/cookietemple.cfg
+++ b/cookietemple/create/templates/cli/cli_python/{{ cookiecutter.project_slug_no_hyphen }}/cookietemple.cfg
@@ -13,3 +13,4 @@ conf_py = docs/conf.py
 ct_sync_level = minor
 
 [sync_files_blacklisted]
+changelog = CHANGELOG.rst

--- a/cookietemple/create/templates/common_files/{{cookiecutter.commonName}}/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/cookietemple/create/templates/common_files/{{cookiecutter.commonName}}/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,7 +11,7 @@ assignees: ''
 
 <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when ... -->
 
-**Describe the solution you'd like**
+**Describe the solution you would like**
 
 <!-- A clear and concise description of what you want to happen. -->
 

--- a/cookietemple/create/templates/common_files/{{cookiecutter.commonName}}/.github/workflows/sync_project.yml
+++ b/cookietemple/create/templates/common_files/{{cookiecutter.commonName}}/.github/workflows/sync_project.yml
@@ -23,7 +23,7 @@ jobs:
               token: '{% raw %}${{ secrets.CT_SYNC_TOKEN }}{% endraw %}'
           name: Check out source-code repository
 
-        - uses: oleksiyrudenko/gha-git-credentials@v1
+        - uses: oleksiyrudenko/gha-git-credentials@v2
           with:
                name: '{{ cookiecutter.creator_github_username }}'
                email: '{{ cookiecutter.email }}'

--- a/cookietemple/create/templates/gui/gui_java/{{ cookiecutter.project_slug }}/cookietemple.cfg
+++ b/cookietemple/create/templates/gui/gui_java/{{ cookiecutter.project_slug }}/cookietemple.cfg
@@ -12,4 +12,5 @@ pom = pom.xml
 ct_sync_level = minor
 
 [sync_files_blacklisted]
+changelog = CHANGELOG.rst
 

--- a/cookietemple/create/templates/lib/lib_cpp/{{ cookiecutter.project_slug }}/cookietemple.cfg
+++ b/cookietemple/create/templates/lib/lib_cpp/{{ cookiecutter.project_slug }}/cookietemple.cfg
@@ -13,4 +13,5 @@ cmake_lists = CMakeLists.txt
 ct_sync_level = minor
 
 [sync_files_blacklisted]
+changelog = CHANGELOG.rst
 

--- a/cookietemple/create/templates/pub/thesis_latex/{{cookiecutter.project_slug}}/cookietemple.cfg
+++ b/cookietemple/create/templates/pub/thesis_latex/{{cookiecutter.project_slug}}/cookietemple.cfg
@@ -3,6 +3,7 @@ current_version = 1.0.0
 
 [bumpversion_files_whitelisted]
 thesis_info = thesis-info.tex
+dot_cookietemple = .cookietemple.yml
 
 [bumpversion_files_blacklisted]
 
@@ -10,4 +11,5 @@ thesis_info = thesis-info.tex
 ct_sync_level = minor
 
 [sync_files_blacklisted]
+changelog = CHANGELOG.rst
 

--- a/cookietemple/create/templates/web/website_python/flask/{{ cookiecutter.project_slug_no_hyphen }}/cookietemple.cfg
+++ b/cookietemple/create/templates/web/website_python/flask/{{ cookiecutter.project_slug_no_hyphen }}/cookietemple.cfg
@@ -3,6 +3,7 @@ current_version = {{ cookiecutter.version }}
 
 [bumpversion_files_whitelisted]
 setup_file = setup.py
+dot_cookietemple = .cookietemple.yml
 
 [bumpversion_files_blacklisted]
 
@@ -10,4 +11,5 @@ setup_file = setup.py
 ct_sync_level = minor
 
 [sync_files_blacklisted]
+changelog = CHANGELOG.rst
 

--- a/cookietemple/create/templates/web/website_python/flask/{{ cookiecutter.project_slug_no_hyphen }}/deployment_scripts/setup.sh
+++ b/cookietemple/create/templates/web/website_python/flask/{{ cookiecutter.project_slug_no_hyphen }}/deployment_scripts/setup.sh
@@ -1,29 +1,42 @@
 #!/bin/bash
 # Reference:
 # https://www.digitalocean.com/community/tutorials/how-to-serve-flask-applications-with-gunicorn-and-nginx-on-ubuntu-18-04
+sudo apt-get install software-properties-common
+sudo apt-add-repository universe
+sudo apt-get update
+sudo apt-get install python3-pip
+sudo apt-get install python3-dev nginx -y
+sudo pip3 install virtualenv
+
+virtualenv dpenv
+source dpenv/bin/activate
+
+sudo apt-get update
+pip3 install gunicorn
+make install
 
 cp /home/{{cookiecutter.vmusername}}/{{cookiecutter.project_slug}}/deployment_scripts/{{cookiecutter.project_slug_no_hyphen}}.service \
 /etc/systemd/system/{{cookiecutter.project_slug_no_hyphen}}.service
 
-systemctl start {{cookiecutter.project_slug}}
+sudo systemctl start {{cookiecutter.project_slug}}
 
-systemctl enable {{cookiecutter.project_slug}}
+sudo systemctl enable {{cookiecutter.project_slug}}
 
 cp /home/{{cookiecutter.vmusername}}/{{cookiecutter.project_slug}}/deployment_scripts/{{cookiecutter.project_slug_no_hyphen}} \
 /etc/nginx/sites-available/{{cookiecutter.project_slug_no_hyphen}}
 
 ln -s /etc/nginx/sites-available/{{cookiecutter.project_slug_no_hyphen}} /etc/nginx/sites-enabled
 
-nginx -t
+sudo nginx -t
 
-systemctl restart nginx
+sudo systemctl restart nginx
 
-ufw delete allow 5000
+sudo ufw delete allow 5000
 
-ufw allow 'Nginx Full'
+sudo ufw allow 'Nginx Full'
 
-add-apt-repository ppa:certbot/certbot -y
+sudo add-apt-repository ppa:certbot/certbot -y
 
-apt install python3-certbot-nginx -y
+sudo apt install python3-certbot-nginx -y
 
-certbot --nginx -d {{cookiecutter.url}} -d www.{{cookiecutter.url}} --non-interactive --agree-tos -m {{cookiecutter.email}}
+sudo certbot --nginx -d {{cookiecutter.url}} -d www.{{cookiecutter.url}} --non-interactive --agree-tos -m {{cookiecutter.email}}

--- a/cookietemple/create/templates/web/website_python/flask/{{ cookiecutter.project_slug_no_hyphen }}/tests/test_{{ cookiecutter.project_slug_no_hyphen }}.py
+++ b/cookietemple/create/templates/web/website_python/flask/{{ cookiecutter.project_slug_no_hyphen }}/tests/test_{{ cookiecutter.project_slug_no_hyphen }}.py
@@ -36,7 +36,6 @@ def create_test_app():
     login = LoginManager()
     login.login_view = 'auth.login'
     login.login_message = 'Please log in to access this page.'
-    mail = Mail()
     bootstrap = Bootstrap()
     babel = Babel()
 
@@ -44,7 +43,6 @@ def create_test_app():
     app.config.from_object(Config)
     migrate.init_app(app, db)
     login.init_app(app)
-    mail.init_app(app)
     bootstrap.init_app(app)
     babel.init_app(app)
 

--- a/cookietemple/create/templates/web/website_python/flask/{{ cookiecutter.project_slug_no_hyphen }}/{{ cookiecutter.project_slug_no_hyphen }}/auth/forms/register_form.py
+++ b/cookietemple/create/templates/web/website_python/flask/{{ cookiecutter.project_slug_no_hyphen }}/{{ cookiecutter.project_slug_no_hyphen }}/auth/forms/register_form.py
@@ -1,13 +1,12 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, SubmitField
-from wtforms.validators import ValidationError, DataRequired, Email, EqualTo
+from wtforms.validators import ValidationError, DataRequired, EqualTo
 from flask_babel import _
 from {{ cookiecutter.project_slug_no_hyphen }}.models.users import User
 
 
 class RegistrationForm(FlaskForm):
     username = StringField(_('Username'), validators=[DataRequired()])
-    email = StringField('Email', validators=[DataRequired(), Email()])
     password = PasswordField(_('Password'), validators=[DataRequired()])
     password2 = PasswordField(
         _('Repeat Password'), validators=[DataRequired(),
@@ -19,7 +18,3 @@ class RegistrationForm(FlaskForm):
         if user is not None:
             raise ValidationError(_('Please use a different username.'))
 
-    def validate_email(self, email):
-        user = User.query.filter_by(email=email.data).first()
-        if user is not None:
-            raise ValidationError(_('Please use a different email address.'))

--- a/cookietemple/custom_cli/click.py
+++ b/cookietemple/custom_cli/click.py
@@ -103,7 +103,7 @@ class HelpErrorHandling(click.Group):
 
         with formatter.section(HelpErrorHandling.get_rich_value("Feedback")):
             formatter.write_text("We are always curious about your opinion on cookietemple. Join our Discord at "
-                                 "https://discord.com/channels/708008788505919599/708008788505919602 and drop us a message: cookies await you.")
+                                 "https://discord.gg/CwRXMdSg and drop us a message: cookies await you.")
 
     def get_command(self, ctx, cmd_name):
         """

--- a/cookietemple/custom_cli/questionary.py
+++ b/cookietemple/custom_cli/questionary.py
@@ -1,9 +1,9 @@
 import logging
 import sys
-from typing import Union
+from typing import Optional, List, Dict, Union
 
 import questionary
-from prompt_toolkit.styles import Style
+from prompt_toolkit.styles import Style  # type: ignore
 from rich import print
 
 log = logging.getLogger(__name__)
@@ -25,9 +25,9 @@ cookietemple_style = Style([
 
 def cookietemple_questionary_or_dot_cookietemple(function: str,
                                                  question: str,
-                                                 choices: list = None,
-                                                 default: str = None,
-                                                 dot_cookietemple: dict = None,
+                                                 choices: Optional[List[str]] = None,
+                                                 default: Optional[str] = None,
+                                                 dot_cookietemple: Dict = None,
                                                  to_get_property: str = None) -> Union[str, bool]:
     """
     Custom selection based on Questionary. Handles keyboard interrupts and default values.
@@ -48,13 +48,13 @@ def cookietemple_questionary_or_dot_cookietemple(function: str,
     except KeyError:
         log.debug(f'.cookietemple.yml file was passed when creating a project, but key {to_get_property}'
                   f' does not exist in the dot_cookietemple dictionary! Assigning default {default} to {to_get_property}.')
-        return default
+        return default  # type: ignore
 
     # There is no .cookietemple.yml file aka dot_cookietemple dict passed -> ask for the properties
-    answer = ''
+    answer: Optional[str] = ''
     try:
         if function == 'select':
-            if default not in choices:
+            if default not in choices:  # type: ignore
                 log.debug(f'Default value {default} is not in the set of choices!')
             answer = getattr(questionary, function)(f'{question}: ', choices=choices, style=cookietemple_style).unsafe_ask()
         elif function == 'password':
@@ -80,4 +80,4 @@ def cookietemple_questionary_or_dot_cookietemple(function: str,
     log.debug(f'User was asked the question: ||{question}|| as: {function}')
     log.debug(f'User selected {answer}')
 
-    return answer
+    return answer  # type: ignore

--- a/cookietemple/info/info.py
+++ b/cookietemple/info/info.py
@@ -133,7 +133,7 @@ class TemplateInfo:
         table.add_column("Version", justify="left")
 
         for template in templates_to_print:
-            table.add_row(f'[bold]{template[0]}', template[1], template[2], template[3], template[4])
+            table.add_row(f'[bold]{template[0]}', template[1], f'{template[2]}\n', template[3], template[4])
 
         log.debug('Printing info table.')
         console = Console()

--- a/cookietemple/info/info.py
+++ b/cookietemple/info/info.py
@@ -1,6 +1,8 @@
 import logging
 import os
 import sys
+from typing import List
+
 from rich.style import Style
 from rich.console import Console
 from rich.table import Table
@@ -34,11 +36,11 @@ class TemplateInfo:
         :param handle: domain/language/template handle (examples: cli or cli-python)
         """
         # list of all templates that should be printed according to the passed handle
-        templates_to_print = []
+        templates_to_print: List[str] = []
         available_templates = load_yaml_file(f'{self.TEMPLATES_PATH}/available_templates.yml')
         specifiers = handle.split('-')
         domain = specifiers[0]
-        global template_info
+        template_info: List[str] = []
 
         # only domain OR language specified
         if len(specifiers) == 1:
@@ -82,7 +84,7 @@ class TemplateInfo:
             self.print_console_output(handle)
 
         # input may be a language so try this
-        templates_flatted = []
+        templates_flatted: List[str] = []
         self.flatten_nested_dict(available_templates, templates_flatted)
         # load all available languages
         available_languages = TemplateInfo.load_available_languages(templates_flatted)

--- a/cookietemple/lint/domains/cli.py
+++ b/cookietemple/lint/domains/cli.py
@@ -1,5 +1,6 @@
 import os
 from subprocess import Popen
+from typing import List
 
 import requests
 from pkg_resources import parse_version
@@ -122,7 +123,7 @@ class CliPythonLint(TemplateLinter, metaclass=GetLintingFunctionsMeta):
         files_fail_ifexists = [
             '__pycache__'
         ]
-        files_warn_ifexists = [
+        files_warn_ifexists: List[str] = [
 
         ]
 
@@ -174,10 +175,10 @@ class CliJavaLint(TemplateLinter, metaclass=GetLintingFunctionsMeta):
         ]
 
         # List of strings. Fails / warns if any of the strings exist.
-        files_fail_ifexists = [
+        files_fail_ifexists: List[str] = [
 
         ]
-        files_warn_ifexists = [
+        files_warn_ifexists: List[str] = [
 
         ]
 

--- a/cookietemple/lint/domains/gui.py
+++ b/cookietemple/lint/domains/gui.py
@@ -1,4 +1,5 @@
 import os
+from typing import List
 
 from cookietemple.lint.template_linter import TemplateLinter, files_exist_linting, GetLintingFunctionsMeta
 
@@ -41,10 +42,10 @@ class GuiJavaLint(TemplateLinter, metaclass=GetLintingFunctionsMeta):
         ]
 
         # List of strings. Fails / warns if any of the strings exist.
-        files_fail_ifexists = [
+        files_fail_ifexists: List[str] = [
 
         ]
-        files_warn_ifexists = [
+        files_warn_ifexists: List[str] = [
 
         ]
 

--- a/cookietemple/lint/domains/lib.py
+++ b/cookietemple/lint/domains/lib.py
@@ -1,4 +1,5 @@
 import os
+from typing import List
 
 from cookietemple.lint.template_linter import TemplateLinter, files_exist_linting, GetLintingFunctionsMeta
 
@@ -46,9 +47,9 @@ class LibCppLint(TemplateLinter, metaclass=GetLintingFunctionsMeta):
         ]
 
         # List of strings. Fails / warns if any of the strings exist.
-        files_fail_ifexists = [
+        files_fail_ifexists: List[str] = [
         ]
-        files_warn_ifexists = [
+        files_warn_ifexists: List[str] = [
         ]
 
         files_exist_linting(self, files_fail, files_fail_ifexists, files_warn, files_warn_ifexists, handle='lib-cpp')

--- a/cookietemple/lint/domains/pub.py
+++ b/cookietemple/lint/domains/pub.py
@@ -1,4 +1,5 @@
 import os
+from typing import List
 
 from cookietemple.lint.template_linter import TemplateLinter, files_exist_linting, GetLintingFunctionsMeta
 
@@ -50,7 +51,8 @@ class PubLatexLint(TemplateLinter, metaclass=GetLintingFunctionsMeta):
         ]
 
         # List of strings. Fails / warns if any of the strings exist.
-        files_fail_ifexists = [
+        files_fail_ifexists: List[str] = [
+
         ]
         files_warn_ifexists = [
             '.travis.yml'

--- a/cookietemple/lint/domains/web.py
+++ b/cookietemple/lint/domains/web.py
@@ -1,5 +1,7 @@
 import os
 from subprocess import Popen
+from typing import List
+
 from rich import print
 
 from cookietemple.custom_cli.questionary import cookietemple_questionary_or_dot_cookietemple
@@ -68,7 +70,7 @@ class WebWebsitePythonLint(TemplateLinter, metaclass=GetLintingFunctionsMeta):
         files_fail_ifexists = [
             '__pycache__'
         ]
-        files_warn_ifexists = [
+        files_warn_ifexists: List[str] = [
 
         ]
 

--- a/cookietemple/lint/lint.py
+++ b/cookietemple/lint/lint.py
@@ -1,6 +1,8 @@
 import logging
 import sys
 from pathlib import Path
+from typing import Union, Any, Optional
+
 from ruamel.yaml import YAML
 from rich import print
 
@@ -14,7 +16,7 @@ from cookietemple.lint.domains.pub import PubLatexLint
 log = logging.getLogger(__name__)
 
 
-def lint_project(project_dir: str, skip_external: bool, is_create: bool = False) -> TemplateLinter:
+def lint_project(project_dir: str, skip_external: bool, is_create: bool = False) -> Optional[TemplateLinter]:
     """
     Verifies the integrity of a project to best coding and practices.
     Runs a set of general linting functions, which all templates share and afterwards runs template specific linting functions.
@@ -38,7 +40,7 @@ def lint_project(project_dir: str, skip_external: bool, is_create: bool = False)
     }
 
     try:
-        lint_obj = switcher.get(template_handle)(project_dir)
+        lint_obj: Union[TemplateLinter, Any] = switcher.get(template_handle)(project_dir)  # type: ignore
     except TypeError:
         print(f'[bold red]Unable to find linter for handle {template_handle}! Aborting...')
         sys.exit(1)
@@ -64,9 +66,9 @@ def lint_project(project_dir: str, skip_external: bool, is_create: bool = False)
         # when linting en existing python cookietemple project, autopep8 should be now optional,
         # since (for example) it messes up Jinja syntax (if included in project)
         if 'python' in template_handle:
-            lint_obj.lint(is_create, skip_external)
+            lint_obj.lint(is_create, skip_external)  # type: ignore
         else:
-            lint_obj.lint(skip_external)
+            lint_obj.lint(skip_external)  # type: ignore
     except AssertionError as e:
         print(f'[bold red]Critical error: {e}')
         print('[bold red] Stopping tests...')
@@ -79,6 +81,8 @@ def lint_project(project_dir: str, skip_external: bool, is_create: bool = False)
     if len(lint_obj.failed) > 0:
         print(f'[bold red] {len(lint_obj.failed)} tests failed! Exiting with non-zero error code.')
         sys.exit(1)
+
+    return None
 
 
 def get_template_handle(dot_cookietemple_path: str = '.cookietemple.yml') -> str:

--- a/cookietemple/lint/template_linter.py
+++ b/cookietemple/lint/template_linter.py
@@ -4,6 +4,7 @@ import os
 import re
 import configparser
 import sys
+from typing import Tuple
 
 import rich.progress
 import rich.markdown
@@ -264,7 +265,7 @@ class TemplateLinter(object):
                 if ('<<COOKIETEMPLE_NO_BUMP>>' not in line and not section == 'bumpversion_files_blacklisted') or '<<COOKIETEMPLE_FORCE_BUMP>>' in line:
                     line_version = re.search(r'(?<!\.)\d+(?:\.\d+){2}(?:-SNAPSHOT)?(?!\.)', line)
                     if line_version:
-                        line_version = line_version.group(0)
+                        line_version = line_version.group(0)  # type: ignore
                         # No match between the current version number and version in source code file
                         if line_version != version:
                             corrected_line = re.sub(r'(?<!\.)\d+(?:\.\d+){2}(?:-SNAPSHOT)?(?!\.)', version, line)
@@ -423,7 +424,7 @@ class ChangelogLinter:
         self.line_counter = 0
         self.header_offset = 0
 
-    def lint_header(self) -> (int, bool, bool):
+    def lint_header(self) -> Tuple[int, bool, bool]:  # type: ignore
         """
         Lint the header which consists of an optional label, the headline CHANGELOG and an optional small description
         """

--- a/cookietemple/lint/template_linter.py
+++ b/cookietemple/lint/template_linter.py
@@ -149,6 +149,14 @@ class TemplateLinter(object):
 
         files_exist_linting(self, files_fail, files_fail_ifexists, files_warn, files_warn_ifexists, is_subclass_calling)
 
+    def lint_cookietemple_config(self):
+        """
+        Lint the cookietemple.cfg file and ensure it meets all requirements for cookietemple.
+        """
+        config_file_path = os.path.join(self.path, 'cookietemple.cfg')
+        linter = ConfigLinter(config_file_path, self)
+        linter.lint_ct_config_file()
+
     def lint_changelog(self):
         """
         Lint the Changelog.rst file
@@ -210,7 +218,7 @@ class TemplateLinter(object):
                                 .replace('// TODO COOKIETEMPLE: ', '') \
                                 .replace('TODO COOKIETEMPLE: ', '').replace('# COOKIETEMPLE TODO: ', '') \
                                 .replace('// COOKIETEMPLE TODO: ', '') \
-                                .replace('COOKIETEMPLE TODO: ', '')\
+                                .replace('COOKIETEMPLE TODO: ', '') \
                                 .strip()
                             self.warned.append(('general-3', f'TODO string found in {self._wrap_quotes(fname)}: {line}'))
 
@@ -238,19 +246,21 @@ class TemplateLinter(object):
         parser.read(f'{self.path}/cookietemple.cfg')
         sections = ['bumpversion_files_whitelisted', 'bumpversion_files_blacklisted']
 
-        current_version = parser.get('bumpversion', 'current_version')
+        try:
+            current_version = parser.get('bumpversion', 'current_version')
+            cwd = os.getcwd()
+            os.chdir(self.path)
 
-        cwd = os.getcwd()
-        os.chdir(self.path)
-
-        # check if the version matches current version in each listed file (depending on whitelisted or blacklisted)
-        for section in sections:
-            for file, path in parser.items(section):
-                self.check_version_match(path, current_version, section)
-        os.chdir(cwd)
-        # Pass message if there weren't any inconsistencies within the version numbers
-        if not any('general-5' in tup[0] for tup in self.failed):
-            self.passed.append(('general-5', 'Versions were consistent over all files'))
+            # check if the version matches current version in each listed file (depending on whitelisted or blacklisted)
+            for section in sections:
+                for file, path in parser.items(section):
+                    self.check_version_match(path, current_version, section)
+            os.chdir(cwd)
+            # Pass message if there weren't any inconsistencies within the version numbers
+            if not any('general-5' in tup[0] for tup in self.failed):
+                self.passed.append(('general-5', 'Versions were consistent over all files'))
+        except configparser.NoOptionError:
+            self.failed.append(('general-5', 'Cannot check versions due to missing current_version in bumpversion config section!'))
 
     def check_version_match(self, path: str, version: str, section: str) -> None:
         """
@@ -261,7 +271,7 @@ class TemplateLinter(object):
         """
         with open(path) as file:
             for line in file:
-                # if a tag is found and (depending on wether its a white or blacklisted file) check if the versions are matching
+                # if a tag is found and (depending on wether it is a white or blacklisted file) check if the versions are matching
                 if ('<<COOKIETEMPLE_NO_BUMP>>' not in line and not section == 'bumpversion_files_blacklisted') or '<<COOKIETEMPLE_FORCE_BUMP>>' in line:
                     line_version = re.search(r'(?<!\.)\d+(?:\.\d+){2}(?:-SNAPSHOT)?(?!\.)', line)
                     if line_version:
@@ -583,3 +593,103 @@ class ChangelogLinter:
             content = f.readlines()
 
         return content
+
+
+class ConfigLinter:
+    def __init__(self, path, linter_ctx: TemplateLinter):
+        self.config_file_path = path
+        self.parser = configparser.ConfigParser()
+        self.linter_ctx = linter_ctx
+
+    def lint_ct_config_file(self):
+        """
+        Lint the sections from the cookietemple.cfg file applying the following rules:
+
+        1.) Every config file should have at least the following sections:
+            bumpversion, bumpversion_files_whitelisted, bumpversion_files_blacklisted,
+            sync_files_blacklisted, sync_level
+
+        2.) 'bumpversion' should contain a 'current_version' value (the project's current version)
+
+        3.) 'bumpversion_files_whitelisted' should contain at least the '.cookietemple.yml' file
+
+        4.) 'sync_level' should contain a 'ct_sync_level' value (and this value should be one of either 'patch', 'minor' or 'major')
+
+        5.) 'sync_files_blacklisted' should contain at least the 'CHANGELOG.rst' file (excluding it from syncing to avoid PR updates)
+        """
+        self.parser.read(f'{self.config_file_path}')
+        no_section_missing = self.check_missing_sections(self.parser.sections())
+        if no_section_missing:
+            check_section_flag = True
+            check_section_flag &= self.check_section(self.parser.items('bumpversion'), 'bumpversion', self.linter_ctx)
+            check_section_flag &= self.check_section(self.parser.items('bumpversion_files_whitelisted'), 'bumpversion_files_whitelisted', self.linter_ctx)
+            check_section_flag &= self.check_section(self.parser.items('sync_level'), 'sync_level', self.linter_ctx)
+            check_section_flag &= self.check_section(self.parser.items('sync_files_blacklisted'), 'sync_files_blacklisted', self.linter_ctx)
+            if check_section_flag:
+                self.linter_ctx.passed.append(('general-7', 'All config sections passed cookietemple linting!'))
+        else:
+            self.linter_ctx.failed.append(('general-7', 'Aborted config section linting. Fix missing sections first!'))
+
+    def check_missing_sections(self, parsed_sections) -> bool:
+        """
+        Examine cookietemple config file for missing sections
+        :param parsed_sections: All parsed sections from the user's cookietemple.cfg file
+        """
+        sections = ['bumpversion', 'bumpversion_files_whitelisted', 'bumpversion_files_blacklisted', 'sync_files_blacklisted', 'sync_level']
+        missing_sections = []
+        # for every section check whether it is in the parsed sections or not
+        for section in sections:
+            if section not in parsed_sections:
+                missing_sections.append(section)
+        # if there were any missing sections, let linter fail
+        if missing_sections:
+            miss_section_info = 'Cookietemple config file misses section' + 's' if len(missing_sections) > 1 else ''
+            self.linter_ctx.failed.append(('general-7', f'{miss_section_info}: {" ".join(section for section in missing_sections)}'))
+            return False
+        else:
+            self.linter_ctx.passed.append(('general-7', 'All required cookietemple.cfg sections were found!'))
+            return True
+
+    def check_section(self, section_items, section_name: str, main_linter: TemplateLinter) -> bool:
+        """
+        Check requirements 2.) - 5.) stated above.
+        :param section_items: A pair (name, value) for all items in a section
+        :param section_name: The sections name
+        :param main_linter: The linter calling the function
+        """
+        # a set containig the section name as a key and its linting rules as values
+        # linting rules made of:
+        #   1.) a tuple with a variable_name and its value ('*' if value does not care for linting)
+        #   => NOTE: if one variable can have multiple valid values, they are separated by '|'
+        #
+        #   2.) a number, stating the minimum number of items in a section (-1 if number does not care)
+        check_set = {
+            'bumpversion': [('current_version', '*'), 1],
+            'bumpversion_files_whitelisted': [('dot_cookietemple', '.cookietemple.yml'), -1],
+            'sync_level': [('ct_sync_level', 'patch|minor|major'), 1],
+            'sync_files_blacklisted': [('changelog', 'CHANGELOG.rst'), -1]
+        }
+        return ConfigLinter.apply_section_linting_rules(section_name, section_items, check_set.get(section_name), main_linter)
+
+    @staticmethod
+    def apply_section_linting_rules(section: str, section_items, section_lint_rules, main_linter: TemplateLinter) -> bool:
+        """
+        For each section, check if the applied linting rules are met!
+        """
+        linting_passed = True
+        section_tuple_needed = section_lint_rules[0]
+        # if a section needs a concrete number of items, check if this holds true for the section
+        if section_lint_rules[1] != -1:
+            linting_passed &= len(section_items) == section_lint_rules[1]
+        # decide, whether we should check for the whole tuple or just any part of it
+        if section_tuple_needed[1] != '*':
+            # it is possible to have several valid values for a concrete section item
+            valid_values = section_tuple_needed[1].split('|')
+            linting_passed &= any(section_item for idx, section_item in enumerate(section_items) if section_items[idx][0] == section_tuple_needed[0] and
+                                  section_items[idx][1] in valid_values)
+        else:
+            linting_passed &= any(section_item for idx, section_item in enumerate(section_items) if section_items[idx][0] == section_tuple_needed[0])
+
+        if not linting_passed:
+            main_linter.failed.append(('general-7', f'Config linting failed for section {section}!'))
+        return linting_passed

--- a/cookietemple/list/list.py
+++ b/cookietemple/list/list.py
@@ -58,7 +58,7 @@ class TemplateLister:
         table.add_column("Version", justify="left")
 
         for template in templates_to_tabulate:
-            table.add_row(f'[bold]{template[0]}', template[1], template[2], template[3], template[4])
+            table.add_row(f'[bold]{template[0]}', template[1], f'{template[2]}\n', template[3], template[4])
 
         log.debug('Printing list table.')
         console = Console()

--- a/cookietemple/sync/sync.py
+++ b/cookietemple/sync/sync.py
@@ -171,13 +171,12 @@ class TemplateSync:
         print('[bold blue]Creating a new template project.')
         # dry create run from dot_cookietemple in tmp directory
         with tempfile.TemporaryDirectory() as tmpdirname:
-            # TODO REFACTOR THIS BY PASSING A PATH PARAM TO CHOOSE DOMAIN WHICH DEFAULTS TO CWD WHEN NOT PASSED (INITIAL CREATE)
             old_cwd = str(Path.cwd())
             log.debug(f'Saving current working directory {old_cwd}.')
             os.chdir(tmpdirname)
             log.debug(f'Changed directory to {tmpdirname}.')
             log.debug(f'Calling choose_domain with {self.dot_cookietemple}.')
-            choose_domain(domain=None, dot_cookietemple=self.dot_cookietemple)
+            choose_domain(path=Path.cwd(), domain=None, dot_cookietemple=self.dot_cookietemple)
             # copy into the cleaned TEMPLATE branch's project directory
             log.debug(f'Copying created template into {self.project_dir}.')
             copy_tree(os.path.join(tmpdirname, self.dot_cookietemple['project_slug']), str(self.project_dir))

--- a/cookietemple/sync/sync.py
+++ b/cookietemple/sync/sync.py
@@ -406,7 +406,20 @@ class TemplateSync:
         Return is_patch_update True if its a micro update (for example 1.2.3 to 1.2.4).
         cookietemple will use this to decide which syncing strategy to apply. Also return both versions.
         """
-        log.debug('Trying to load the projects template version and the cookietemple template version.')
+        # Try to compare against the development branch, since it is the most up to date (usually).
+        # If a development branch does not exist compare against master.
+        repo = git.Repo(project_dir)
+        try:
+            repo.git.checkout('development')
+        except git.exc.GitCommandError:
+            print('[bold red]Could not checkout development branch. Trying to checkout master...')
+            try:
+                repo.git.checkout('master')
+            except git.exc.GitCommandError as e:
+                print(f'[bold red]Could not checkout master branch.\n{e}')
+                sys.exit(1)
+
+        log.debug('Loading the project\'s template version and the cookietemple template version.')
         template_version_last_sync, template_handle = TemplateSync.sync_load_project_template_version_and_handle(project_dir)
         template_version_last_sync = version.parse(template_version_last_sync)
         current_ct_template_version = version.parse(TemplateSync.sync_load_template_version(template_handle))

--- a/cookietemple/sync/sync.py
+++ b/cookietemple/sync/sync.py
@@ -8,7 +8,9 @@ import sys
 from configparser import ConfigParser, NoSectionError
 from distutils.dir_util import copy_tree
 from subprocess import Popen, PIPE
-import git
+from typing import Tuple
+
+import git  # type: ignore
 import json
 import os
 import requests
@@ -397,7 +399,7 @@ class TemplateSync:
         print(f'[bold blue]\nSuccessfully updated sync secret for project {project_name}.')
 
     @staticmethod
-    def has_template_version_changed(project_dir: Path) -> (bool, bool, bool, str, str):
+    def has_template_version_changed(project_dir: Path) -> Tuple[bool, bool, bool, str, str]:
         """
         Check, if the cookietemple template has been updated since last check/sync of the user.
 
@@ -421,19 +423,19 @@ class TemplateSync:
 
         log.debug('Loading the project\'s template version and the cookietemple template version.')
         template_version_last_sync, template_handle = TemplateSync.sync_load_project_template_version_and_handle(project_dir)
-        template_version_last_sync = version.parse(template_version_last_sync)
+        template_version_last_sync = version.parse(template_version_last_sync)  # type: ignore
         current_ct_template_version = version.parse(TemplateSync.sync_load_template_version(template_handle))
         log.debug(f'Projects template version is {template_version_last_sync} and cookietemple template version is {current_ct_template_version}')
         is_major_update, is_minor_update, is_patch_update = False, False, False
 
         # check if a major change happened (for example 1.2.3 to 2.0.0)
-        if template_version_last_sync.major < current_ct_template_version.major:
+        if template_version_last_sync.major < current_ct_template_version.major:  # type: ignore
             is_major_update = True
         # check if minor update happened (for example 1.2.3 to 1.3.0)
-        elif template_version_last_sync.minor < current_ct_template_version.minor:
+        elif template_version_last_sync.minor < current_ct_template_version.minor:  # type: ignore
             is_minor_update = True
         # check if a patch update happened (for example 1.2.3 to 1.2.4)
-        elif template_version_last_sync.micro < current_ct_template_version.micro:
+        elif template_version_last_sync.micro < current_ct_template_version.micro:  # type: ignore
             is_patch_update = True
         return is_major_update, is_minor_update, is_patch_update, str(template_version_last_sync), str(current_ct_template_version)
 
@@ -451,7 +453,7 @@ class TemplateSync:
         return load_ct_template_version(handle, available_templates_path)
 
     @staticmethod
-    def sync_load_project_template_version_and_handle(project_dir: Path) -> str:
+    def sync_load_project_template_version_and_handle(project_dir: Path) -> Tuple[str, str]:
         """
         Return the project template version since last sync for user (if no sync happened, return initial create version of the template)
 

--- a/cookietemple/upgrade/upgrade.py
+++ b/cookietemple/upgrade/upgrade.py
@@ -57,12 +57,12 @@ class UpgradeCommand:
             return True
 
         if parse_version(latest_local_version) > parse_version(latest_pypi_version):
-            print(f'[bold yellow]Installed version {latest_local_version} of mlf-core is newer than the latest release {latest_pypi_version}!'
+            print(f'[bold yellow]Installed version {latest_local_version} of cookietemple is newer than the latest release {latest_pypi_version}!'
                   f' You are running a nightly version and features may break!')
         elif parse_version(latest_local_version) == parse_version(latest_pypi_version):
             return True
         else:
-            print(f'[bold red]Installed version {latest_local_version} of mlf-core is outdated. Newest version is {latest_pypi_version}!')
+            print(f'[bold red]Installed version {latest_local_version} of cookietemple is outdated. Newest version is {latest_pypi_version}!')
             return False
 
         return False

--- a/cookietemple/upgrade/upgrade.py
+++ b/cookietemple/upgrade/upgrade.py
@@ -65,6 +65,8 @@ class UpgradeCommand:
             print(f'[bold red]Installed version {latest_local_version} of mlf-core is outdated. Newest version is {latest_pypi_version}!')
             return False
 
+        return False
+
     @classmethod
     def upgrade_cookietemple(cls) -> None:
         """

--- a/docs/adding_new_templates.rst
+++ b/docs/adding_new_templates.rst
@@ -107,12 +107,12 @@ The file tree of the template should resemble
         ├── cookietemple.cfg
         └── README.rst
 
-3. | Now it is time to subclass the :code:`TemplateCreator` to implement all required functions to create our template!
+3. | Now it is time to subclass the ``TemplateCreator`` to implement all required functions to create our template!
    | Let's edit ``/create/domains/cli_creator.py``. Note that for new domains you would simply create a new file called DomainCreator.
    | In this case we suggest to simply copy the code of an existing Creator and adapt it to the new domain. Your new domain may make use of other creation functions instead of :code:`create_template_without_subdomain`, if they for example contain subdomains. You can examine :code:`create/TemplatorCreator.py` to see what's available. You may also remove functions such as the creation of common files.
    | If we have any brainfuck specific cookiecutter variables that we need to populate, we may add them to the TemplateStructCli.
    | Our brainfuck templates does not have them, so we just leave it as is.
-   | For the next step we simply go through the :code:`CliCreator` class and add our brainfuck template where required. Moreover, we implement a :code:`cli_brainfuck_options` function, which we use to prompt for template specific cookiecutter variables.
+   | For the next step we simply go through the ``CliCreator`` class and add our brainfuck template where required. Moreover, we implement a ``cli_brainfuck_options`` function, which we use to prompt for template specific cookiecutter variables.
    | Assuming ``cli_creator.py`` already contains a ``cli-java`` template
 
 .. code-block:: python
@@ -143,7 +143,7 @@ The file tree of the template should resemble
             self.CLI_JAVA_TEMPLATE_VERSION = super().load_version('cli-java')
             self.CLI_BRAINFUCK_TEMPLATE_VERSION = super().load_version('cli-brainfuck')
 
-        def create_template(self, dot_cookietemple: dict or None):
+        def create_template(self, path: Path, dot_cookietemple: dict or None):
             """
             Handles the CLI domain. Prompts the user for the language, general and domain specific options.
             """

--- a/docs/adding_new_templates.rst
+++ b/docs/adding_new_templates.rst
@@ -298,23 +298,7 @@ We need to ensure that our new linting function is found when linting is applied
 
 Our shiny new CliBrainfuckLinter is now ready for action!
 
-6. | Now it´s time to add some tests for our new template
-
-   It´s important to add tests for the new template to cookietemple, at least you should
-   test the creation and linting of the new template, besides any special code that comes with the new template.
-   The tests are located inside the :code:`tests` directory. If you developed a new template
-   make sure to add the new :code:`Linter` and/or :code:`Creator`. Please note, that you have to name your test files and functions like
-   :code:`test_*` otherwise they won´t be recognized by :code:`pytest`. Examine the tests for the other templates to adapt them to your template.
-
-   You can run the tests using the :code:`tox` command. Make sure you run this command inside the directory where the :code:`tox.ini` file is.
-   An important note when using :code:`tox`: Tox is designed to run inside :code:`virtualenv` and not with :code:`conda`. Depending on your OS,
-   your python version or your environment you may run into an :code:`InterpreterNotFound-Exception`. To fix this, you may have to change :code:`envlist = py37, py38, flake8`
-   to :code:`envlist = python3.7, python3.8, flake8`.
-
-   Another more simple option is to run :code:`make test` to run all tests (make sure your in the top level directory of cookietemple when calling this command).
-
-
-7. | The only thing left to do now is to add a new Github Actions workflow for our template. Let's go one level up in the folder tree and create :code:`.github/workflows/create_cli_brainfuck.yml`.
+6. | The only thing left to do now is to add a new Github Actions workflow for our template. Let's go one level up in the folder tree and create :code:`.github/workflows/create_cli_brainfuck.yml`.
    | We want to ensure that if we change something in our template, that it still builds!
 
 .. code-block:: bash
@@ -360,7 +344,7 @@ Our shiny new CliBrainfuckLinter is now ready for action!
 
     We were pleasently surprised to see that someone already made a Github Action for brainfuck.
 
-8. | Finally, we add some documentation to :code:`/docs/available_templates.rst` and explain the purpose, design and frameworks/libraries.
+7. | Finally, we add some documentation to :code:`/docs/available_templates.rst` and explain the purpose, design and frameworks/libraries.
 
    That's it! We should now be able to try out your new template using :code:`cookietemple create`
    The template should be creatable, it should automatically lint after the creation and Github support should be enabled as well! If we run :code:`cookietemple list`

--- a/docs/adding_new_templates.rst
+++ b/docs/adding_new_templates.rst
@@ -185,7 +185,7 @@ The file tree of the template should resemble
             self.cli_struct.template_version, self.cli_struct.template_handle = switcher_version.get(
                 self.cli_struct.language.lower()), f'cli-{self.cli_struct.language.lower()}'
 
-            super().process_common_operations(domain='cli', language=self.cli_struct.language, dot_cookietemple=dot_cookietemple)
+            super().process_common_operations(path=Path(path).resolve(), domain='cli', language=self.cli_struct.language, dot_cookietemple=dot_cookietemple)
 
         def cli_python_options(self, dot_cookietemple: dict or None):
             """ Prompts for cli-python specific options and saves them into the CookietempleTemplateStruct """

--- a/docs/available_templates/cli_java.rst
+++ b/docs/available_templates/cli_java.rst
@@ -89,13 +89,16 @@ Included frameworks/libraries
 3. `GraalVM Native Image <https://www.graalvm.org/docs/reference-manual/native-image/>`_ to build platform dependent self-contained executables
 4. `JUnit 5 <https://junit.org/junit5/>`_ as main testing framework
 5. Preconfigured `readthedocs <https://readthedocs.org/>`_
-6. Five Github workflows:
+6. Seven Github workflows:
 
-  1. :code:`build_docs.yml`, which builds the readthedocs documentation.
-  2. :code:`build_deploy.yml`, which builds the cli-java project into Linux, MacOS and Windows executables. They are deployed as build artifacts.
-  3. :code:`run_checkstyle.yml`, which runs `checkstyle <https://checkstyle.sourceforge.io/>`_ linting using Google's ruleset.
-  4. :code:`run_tests.yml`, which runs all JUnit tests.
-  5. :code:`pr_to_master_from_patch_release_only`: Please read :ref:`pr_master_workflow_docs`.
+  1. ``build_docs.yml``, which builds the Read the Docs documentation.
+  2. ``build_deploy.yml``, which builds the cli-java project into Linux, MacOS and Windows executables. They are deployed as build artifacts.
+  3. ``run_checkstyle.yml``, which runs `checkstyle <https://checkstyle.sourceforge.io/>`_ linting using Google's ruleset.
+  4. ``run_tests.yml``, which runs all JUnit tests.
+  5. ``pr_to_master_from_patch_release_only``: Please read :ref:`pr_master_workflow_docs`.
+  6. ``check_no_SNAPSHOT_master.yml``: Please read :ref:`pr_master_workflow_docs`
+  7. ``run_cookietemple_lint.yml``, which runs ``cookietemple lint`` on the project.
+  8. ``sync_project.yml``, which syncs the project to the most recent cookietemple template version
 
 Usage
 ^^^^^^^^

--- a/docs/available_templates/cli_python.rst
+++ b/docs/available_templates/cli_python.rst
@@ -80,16 +80,19 @@ Included frameworks/libraries
 3. `pytest <https://docs.pytest.org/en/latest/>`_ or `unittest <https://docs.python.org/3/library/unittest.html>`_ as testing frameworks
 4. Preconfigured `tox <https://tox.readthedocs.io/en/latest/>`_ to run pytest matrices with different Python environments
 5. Preconfigured `readthedocs <https://readthedocs.org/>`_
-6. Eight Github workflows:
+6. Eleven Github workflows:
 
-  1. :code:`build_docs.yml`, which builds the readthedocs documentation.
-  2. :code:`build_package.yml`, which builds the cli-python package.
-  3. :code:`run_flake8_linting.yml`, which runs `flake8 <https://flake8.pycqa.org/en/latest/>`_ linting.
-  4. :code:`run_tox_testsuite.yml`, which runs the tox testing suite.
-  5. :code:`publish_package.yml`, which publishes the package to PyPi. Note that it only runs on Github release and requires PyPi secrets to be set up.
-  6. :code:`run_codecov`, apply codecov to your project/PRs in your project and create automatically a report with the details at `codecov.io <https://codecov.io>`_
-  7. :code:`run_bandit`, run `bandit <https://github.com/PyCQA/bandit>`_ to discover security issues in your python code
-  8. :code:`pr_to_master_from_patch_release_only`: Please read :ref:`pr_master_workflow_docs`.
+  1. ``build_docs.yml``, which builds the readthedocs documentation.
+  2. ``build_package.yml``, which builds the cli-python package.
+  3. ``run_flake8_linting.yml``, which runs `flake8 <https://flake8.pycqa.org/en/latest/>`_ linting.
+  4. ``run_tox_testsuite.yml``, which runs the tox testing suite.
+  5. ``publish_package.yml``, which publishes the package to PyPi. Note that it only runs on Github release and requires PyPi secrets to be set up.
+  6. ``run_codecov``, apply codecov to your project/PRs in your project and create automatically a report with the details at `codecov.io <https://codecov.io>`_
+  7. ``run_bandit``, run `bandit <https://github.com/PyCQA/bandit>`_ to discover security issues in your python code
+  8. ``pr_to_master_from_patch_release_only``: Please read :ref:`pr_master_workflow_docs`.
+  9. ``check_no_SNAPSHOT_master.yml``: Please read :ref:`pr_master_workflow_docs`
+  10. ``run_cookietemple_lint.yml``, which runs ``cookietemple lint`` on the project.
+  11. ``sync_project.yml``, which syncs the project to the most recent cookietemple template version
 
 
 We highly recommend to use click (if commandline interface is required) together with pytest.

--- a/docs/available_templates/gui_java.rst
+++ b/docs/available_templates/gui_java.rst
@@ -90,14 +90,17 @@ Included frameworks/libraries
 5. `JUnit 5 <https://junit.org/junit5/>`_ for unit tests
 6. `TestFX <https://github.com/TestFX/TestFX>`_ for JavaFX GUI tests
 7. Preconfigured `readthedocs <https://readthedocs.org/>`_
-8. Six Github workflows:
+8. Nine Github workflows:
 
-  1. :code:`build_docs.yml`, which builds the readthedocs documentation.
-  2. :code:`compile_package.yml`, which compiles the gui-java project.
-  3. :code:`run_java_linting.yml`, which runs `checkstyle <https://checkstyle.sourceforge.io/>`_ linting using Google's ruleset.
-  4. :code:`run_tests.yml`, which runs the Unit tests. Note that this workflow is currently disabled, since GUI unittests are not possible using Github Actions.
-  5. :code:`run_codecov`, apply codecov to your project/PRs in your project and create automatically a report with the details at `codecov.io <https://codecov.io>`_
-  6. :code:`pr_to_master_from_patch_release_only`: Please read :ref:`pr_master_workflow_docs`.
+  1. ``build_docs.yml``, which builds the readthedocs documentation.
+  2. ``compile_package.yml``, which compiles the gui-java project.
+  3. ``run_java_linting.yml``, which runs `checkstyle <https://checkstyle.sourceforge.io/>`_ linting using Google's ruleset.
+  4. ``run_tests.yml``, which runs the Unit tests. Note that this workflow is currently disabled, since GUI unittests are not possible using Github Actions.
+  5. ``run_codecov``, apply codecov to your project/PRs in your project and create automatically a report with the details at `codecov.io <https://codecov.io>`_
+  6. ``pr_to_master_from_patch_release_only``: Please read :ref:`pr_master_workflow_docs`.
+  7. ``check_no_SNAPSHOT_master.yml``: Please read :ref:`pr_master_workflow_docs`
+  8. ``run_cookietemple_lint.yml``, which runs ``cookietemple lint`` on the project.
+  9. ``sync_project.yml``, which syncs the project to the most recent cookietemple template version.
 
 Usage
 ^^^^^^^^

--- a/docs/available_templates/web_website_python.rst
+++ b/docs/available_templates/web_website_python.rst
@@ -229,16 +229,19 @@ make heavy use of its extensions.
 3. `pytest <https://docs.pytest.org/en/latest/>`_ or `unittest <https://docs.python.org/3/library/unittest.html>`_ as testing frameworks
 4. Preconfigured `tox <https://tox.readthedocs.io/en/latest/>`_ to run pytest matrices with different Python environments
 5. Preconfigured `readthedocs <https://readthedocs.org/>`_
-6. Eight Github workflows:
+6. Eleven Github workflows:
 
-  1. :code:`build_docs.yml`, which builds the readthedocs documentation.
-  2. :code:`build_package.yml`, which builds the web-template package.
-  3. :code:`run_flake8_linting.yml`, which runs `flake8 <https://flake8.pycqa.org/en/latest/>`_ linting.
-  4. :code:`run_tox_testsuite.yml`, which runs the tox testing suite.
-  5. :code:`run_css_lint.yml`, which runs `Stylelint <https://stylelint.io/>`_ CSS linting.
-  6. :code:`run_codecov`, apply codecov to your project/PRs in your project and create automatically a report with the details at `codecov.io <https://codecov.io>`_
-  7. :code:`run_bandit`, run `bandit <https://github.com/PyCQA/bandit>`_ to discover security issues in your python code
-  8. :code:`pr_to_master_from_patch_release_only`: Please read :ref:`pr_master_workflow_docs`.
+  1. ``build_docs.yml``, which builds the readthedocs documentation.
+  2. ``build_package.yml``, which builds the web-template package.
+  3. ``run_flake8_linting.yml``, which runs `flake8 <https://flake8.pycqa.org/en/latest/>`_ linting.
+  4. ``run_tox_testsuite.yml``, which runs the tox testing suite.
+  5. ``run_css_lint.yml``, which runs `Stylelint <https://stylelint.io/>`_ CSS linting.
+  6. ``run_codecov``, apply codecov to your project/PRs in your project and create automatically a report with the details at `codecov.io <https://codecov.io>`_
+  7. ``run_bandit``, run `bandit <https://github.com/PyCQA/bandit>`_ to discover security issues in your python code
+  8. ``pr_to_master_from_patch_release_only``: Please read :ref:`pr_master_workflow_docs`.
+  9. ``check_no_SNAPSHOT_master.yml``: Please read :ref:`pr_master_workflow_docs`
+  10. ``run_cookietemple_lint.yml``, which runs ``cookietemple lint`` on the project.
+  11. ``sync_project.yml``, which syncs the project to the most recent cookietemple template version
 
 
 We highly recommend to use click (if commandline interface is required) together with pytest.

--- a/docs/available_templates/web_website_python.rst
+++ b/docs/available_templates/web_website_python.rst
@@ -345,26 +345,10 @@ There are a few requirements needed in order to deploy:
 
 If you meet all the requirements above login (for example via :bash:`$ ssh yourvmusername@your-servers-IP`) into your server:
 
-To install pip3 you need to do the following:
- 1. ``$ sudo apt-get install software-properties-common``
- 2. ``$ sudo apt-add-repository universe``
- 3. ``$ sudo apt-get update``
- 4. ``$ sudo apt-get install python3-pip``
+Now, you need to clone your repository in order to start the deployment process.
+So ``$ git clone <<GITHUB_URL_OF_YOUR_PROJECT>>`` and cd ``$ YOUR_PROJECTS_TOP_LEVEL_DIRECTORY``.
+Now simply run ``$ source deployment_scripts/setup.sh`` and the deployment starts. You may be prompted for your password as some commands run need ``sudo`` rights.
 
-In order to run the setup script a few more steps are required:
-
- 1. Install the python3-dev dependencies and nginx using :bash:`$ sudo apt-get install python3-dev nginx -y`
- 2. Clone your GitHub repository using :bash:`$ git clone https://github.com/<you_github_username>/<your_project_name>`
- 3. Next cd into it via :bash:`$ cd <your_project_name>`
- 4. Then, we need to install and create a virtualenv :bash:`$ sudo pip3 install virtualenv` (note the sudo here!).
- 5. Create a virtualenv named :bash:`dpenv` using :bash:`$ virtualenv dpenv`. You must name your environment like this! Also, make sure your current working directory is your project's top level directory!
- 6. Activate the virtualenv with :bash:`$ source dpenv/bin/activate`
- 7. ``$ sudo apt-get update``
- 8. ``$ pip3 install gunicorn``
- 9. ``$ python3 setup.py clean --all install`` (no sudo here, as we don't need to install system wide)
-
-When done, you can now fire up the setup script to deploy your application:
-Use :bash:`$ sudo bash deployment_scripts/setup.sh` and deployment process starts.
 
 **Important**:
 Currently, one more step is required to get ``https`` redirecting to work properly. This will be included into a script in the future, to automate this process.

--- a/docs/bump_version.rst
+++ b/docs/bump_version.rst
@@ -5,7 +5,7 @@ Bumping the version of an existing project
 ==============================================
 
 Increasing the version of an already existing project is often times a cumbersome and error prone process, since the version has to be changed in multiple places.
-To facilitate this process, cookietemple provides a ``bump-version`` command, which conveniently increases the version across several files.
+To facilitate this process, cookietemple provides a ``bump-version`` command, which conveniently increases the version across several files and commits them.
 Additionally, bump-version inserts a new section into the changelog using the specified new version.
 
 .. code::

--- a/docs/community.rst
+++ b/docs/community.rst
@@ -11,7 +11,7 @@ Development Leads
 -------------------
 
 - Lukas Heumos (`@zethson Github <https://github.com/zethson/>`_, `@Lukas Heumos Twitter <https://twitter.com/LukasHeumos>`_)
-- Philipp Ehmele (`@imipenem Github <https://github.com/imipenem>`_, `@Philipp Ehmele Twitter <https://twitter.com/1207_philipp>`_)
+- Philipp Ehmele (`@imipenem Github <https://github.com/imipenem>`_, `@Philipp Ehmele Twitter <https://twitter.com/Farwent_>`_)
 
 Core contributors
 ------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,8 +21,8 @@ project = u'cookietemple'
 copyright = u'2020, Lukas Heumos, Philipp Ehmele, the cookiejar organization'
 author = u'Lukas Heumos, Philipp Ehmele, the cookiejar organization'
 
-version = '1.0.1'
-release = '1.0.1'
+version = '1.2.0'
+release = '1.2.0'
 
 language = None
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -45,7 +45,7 @@ cookietemple's Github support requires access to your Github repositories to cre
 Github manages these access rights through Personal Access Tokens (PAT).
 If you are using cookietemple's Github support for the first time ``cookietemple config pat`` will be run and you will be prompted for your Github PAT.
 Please refer to the `official documentation <https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line>`_ on how to create one.
-cookietemple only requires ``repo`` access, so you only need to tick this box. This ensures that your PAT would not even allow for the deletion of repositories.
+cookietemple requires ``repo`` access and ``workflow``. This ensures that your PAT would not even allow for the deletion of repositories.
 cookietemple then encrypts the Personal Access Token, adds the encrypted token to the ``cookietemple_conf.cfg`` file and saves the key locally in a hidden place.
 This is safer than Github's official way, which recommends the usage of environment variables or Github Credentials, which both save the token in plaintext.
 It is still strongly advised to secure your personal computer and not allow any foe to get access.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -123,4 +123,6 @@ Tips
 
 To run a subset of tests::
 
-$ py.test tests.test_cookietemple
+.. code-block:: console
+
+    $ py.test tests/something

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -7,7 +7,7 @@ Contributing
 ============
 
 Contributions are welcome and greatly appreciated! Every little bit helps and credit will always be given.
-If you have any questions or want to get in touch with the core team feel free to join our `Discord server <https://discord.com/channels/708008788505919599/708008788505919602>`_.
+If you have any questions or want to get in touch with the core team feel free to join our `Discord server <https://discord.com/invite/PYF8NUk>`_.
 
 You can contribute in many ways:
 

--- a/docs/create.rst
+++ b/docs/create.rst
@@ -34,6 +34,7 @@ Flags
 ------
 
 - ``--domain`` : To directly create a template of the the corresponding domain.
+- ``--path`` [CWD]: An absolute or relative path to create the template at.
 
   All further prompts will still be asked for. Example: ``cli``.
   It is also possible to directly create a specific template using its handle

--- a/docs/github_support.rst
+++ b/docs/github_support.rst
@@ -20,7 +20,7 @@ git branches can be understood as diverging copies of the main line of developme
 To learn more about branches read `Branches in a Nutshell <https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell>`_ of the `Pro Git Book <https://git-scm.com/book>`_.
 A simple best practice development workflow follows the pattern that the ``master`` branch always contains the latest released code.
 It should only be touched for new releases. Code on the ``master`` branch must compile and be as bug free as possible.
-Development takes place on the ``development`` branch. All parallelly developed features eventually make it into this branch.
+Development takes place on the ``development`` branch. All in parallel developed features eventually make it into this branch.
 The ``development`` branch should always compile, but it may contain incomplete features or known bugs.
 cookietemple creates a ``TEMPLATE`` branch, which is required for :ref:`sync` to work and should not be touched manually.
 
@@ -95,6 +95,8 @@ Some common error sources are:
 `the Github status page <https://www.githubstatus.com/>`_.
 
 3. A repo with the same name already exists in your account/your organisation.
+
+4. Your Github Token/Secret does not have all required permissions (all repository and workflow permissions).
 
 Creation fails, ok: But how can I then access the full features of cookietemple?
 You can try to fix the issue (or wait some time on case, for example, when Github is down) and then process to create a Github repository manually.

--- a/docs/github_support.rst
+++ b/docs/github_support.rst
@@ -53,19 +53,20 @@ The developers should ensure that all workflows always pass before merging, sinc
 pr_to_master_from_patch_release_only workflow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-All templates feature a workflow called ``pr_to_master_from_patch_release_only.yml``.
-This workflow runs everytime a PR to your projects master branch is created. It fails, if the PR to the ``master`` branch
-origins from a branch that does not contain ``PATCH`` or ``release`` in its branch name.
+All templates feature ``pr_to_master_from_patch_release_only.yml`` and a ``check_no_SNAPSHOT_master.yml`` workflows.
+These workflow runs everytime a PR to your projects master branch is created. It fails, if the PR to the ``master`` branch
+origins from a branch that does not contain ``patch`` or ``release`` in its branch name.
 If development code is written on a branch called ``development``and a new release of the project is to be made,
 one should create a ``release`` branch only for this purpose and then merge it into ``master`` branch.
 This ensures that new developments can already be merged into ``development``, while the release is finally prepared.
-The ``PATCH`` branch should be used for required ``hotfixes`` (checked out directly from ``master`` branch) because, in the meantime, there might
+The ``patch`` branch should be used for required ``hotfixes`` (checked out directly from ``master`` branch) because, in the meantime, there might
 multiple developments going on at ``development`` branch and you dont want to interfere with them.
+Pull requests against the master branch should not contain any ``SNAPSHOT`` versions, since they are only used for development versions.
 
 sync_project.yml
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 All templates also feature this workflow. This workflow is used for automatic syncing (if enabled) your project with the latest cookietemple template version.
-The workflow is run on push events, although this behavior can be customized if desired.
+The workflow is run every night, although this behavior can be customized if desired.
 The workflow calls ``cookietemple sync``, which first checks whether a new template version is available and if so it submits a pull request.
 For more details please visit :ref:`sync`.
 
@@ -111,5 +112,4 @@ Issue labels
 
 cookietemple's Github support automatically creates `issue labels <https://help.github.com/en/github/managing-your-work-on-github/labeling-issues-and-pull-requests>`_.
 Currently the following labels are automatically created:
-https://en.wikipedia.org/wiki/Continuous_integration
 1. dependabot: All templates, which include `Dependabot <https://dependabot.com/>`_ support label all Dependabot pull requests with this label.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,7 +13,6 @@ Stable release
 To install cookietemple, run this command in your terminal:
 
 .. code-block:: console
-    :linenos:
 
     $ pip install cookietemple
 
@@ -34,28 +33,24 @@ The sources for cookietemple can be downloaded from the `Github repo`_.
 You can either clone the public repository:
 
 .. code-block:: console
-    :linenos:
 
     $ git clone git://github.com/cookiejardealer/cookietemple
 
 Or download the `tarball`_:
 
 .. code-block:: console
-    :linenos:
 
     $ curl  -OL https://github.com/cookiejardealer/cookietemple/tarball/master
 
 Once you have a copy of the source, you can install it with:
 
 .. code-block:: console
-    :linenos:
 
     $ pip install .
 
 Alternatively you can also install it using the Makefile:
 
 .. code-block:: console
-    :linenos:
 
     $ make install
 

--- a/docs/lint.rst
+++ b/docs/lint.rst
@@ -106,6 +106,25 @@ general-6
   The version above another changelog section should always be *greater* than the section below (e.g. 1.1.0 above 1.0.0).
   Every section must have the headings ``**Added**``, ``**Fixed**``, ``**Dependencies**`` and ``**Deprecated**``.
 
+general-7
+~~~~~~~~~~~~~
+
+| ``cookietemple.cfg`` linting failed. The ``cookietemple.cfg`` plays a major role in cookietemple's ``sync`` and ``bump-version`` functionality.
+
+The linter ensures that following requirements are met:
+
+
+1.) Every config file should have at least the following sections: ``bumpversion, bumpversion_files_whitelisted, bumpversion_files_blacklisted, sync_files_blacklisted, sync_level``
+
+2.) ``bumpversion`` should only contain a ``current_version`` value (the project's current version)
+
+3.) ``bumpversion_files_whitelisted`` should contain at least the ``.cookietemple.yml`` file in the ``dot_cookietemple`` variable
+
+4.) ``sync_level`` should only contain a ``ct_sync_level`` value (and this value should be one of either ``patch``, ``minor`` or ``major``)
+
+5.) ``sync_files_blacklisted`` should contain at least the ``CHANGELOG.rst`` file (excluding it from syncing to avoid PR updates)
+
+
 cli-python
 ^^^^^^^^^^^^
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx==3.3.0
+Sphinx==3.3.1
 sphinx-automodapi==0.13
 sphinx_rtd_theme==0.5.0

--- a/docs/sync.rst
+++ b/docs/sync.rst
@@ -8,6 +8,7 @@ Syncing is supposed to integrate any changes to the cookietemple templates back 
 When ``cookietemple sync`` is invoked, cookietemple checks whether a new version of the corresponding template for the current project is available.
 If so, cookietemple creates a temporary project with the most recent template and pushes it to the ``TEMPLATE`` branch.
 Next, a pull request is submitted to the ``development`` branch.
+Please note that the required ``CT_SYNC_TOKEN`` (see below) is automatically set and manual syncing should be avoided if possible.
 
 
 The syncing process is configurable by setting the desired lower syncing boundary level and blacklisting files from syncing (see :ref:`sync_config`).
@@ -59,7 +60,7 @@ Sync level
 ~~~~~~~~~~~~~~~~
 
 Since cookietemple strongly adheres to semantic versioning our templates do too.
-Hence, it is customizable whether only major, minor or all (= patch level) releases of the template should trigger cookietemple sync.
+Hence, it is customizable whether only major, minor or patch releases of the template should trigger cookietemple sync.
 The sync level therefore specifies a lower boundary. It can be configured in the::
 
     [sync_level]

--- a/docs/warp.rst
+++ b/docs/warp.rst
@@ -17,6 +17,7 @@ However, ``warp`` can also be applied to .NET Core projects, NodeJS and others, 
 
 The resulting binary is self contained and does not have any additional dependencies. Note however, that the binaries are **not** cross platform. You need to compile and package on the target platform.
 For more information please read the `Warp README <https://github.com/dgiagio/warp>`_.
+Currently no cookietemple template requires Warp.
 
 Warp setup
 ---------------

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,18 @@
+# Global options:
+
+[mypy]
+python_version = 3.9
+
+# Per-module options:
+
+[mypy-pytest]
+ignore_missing_imports = True
+
+[mypy-git]
+ignore_missing_imports = True
+
+[mypy-ruaeml]
+ignore_missing_imports = True
+
+[mypy-rich]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,3 +19,9 @@ ignore_missing_imports = True
 
 [mypy-github.*]
 ignore_missing_imports = True
+
+[mypy-questionary.*]
+ignore_missing_imports = True
+
+[mypy-packaging.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,7 +11,7 @@ ignore_missing_imports = True
 [mypy-git]
 ignore_missing_imports = True
 
-[mypy-ruaeml]
+[mypy-ruamel]
 ignore_missing_imports = True
 
 [mypy-rich]

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,14 +5,17 @@ python_version = 3.9
 
 # Per-module options:
 
-[mypy-pytest]
+[mypy-pytest.*]
 ignore_missing_imports = True
 
-[mypy-git]
+[mypy-git.*]
 ignore_missing_imports = True
 
-[mypy-ruamel]
+[mypy-ruamel.*]
 ignore_missing_imports = True
 
-[mypy-rich]
+[mypy-rich.*]
+ignore_missing_imports = True
+
+[mypy-github.*]
 ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ GitPython==3.1.11
 autopep8==1.5.4
 cffi==1.14.3
 cryptography==3.2.1
-requests==2.24.0
+requests==2.25.0
 rich==9.2.0
 packaging==20.4
 appdirs==1.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ autopep8==1.5.4
 cffi==1.14.3
 cryptography==3.2.1
 requests==2.24.0
-rich==9.1.0
+rich==9.2.0
 packaging==20.4
 appdirs==1.4.4
 questionary==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ requests==2.24.0
 rich==9.2.0
 packaging==20.4
 appdirs==1.4.4
-questionary==1.7.0
+questionary==1.8.0
 pynacl==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ requests==2.25.0
 rich==9.2.0
 packaging==20.4
 appdirs==1.4.4
-questionary==1.8.0
+questionary==1.8.1
 pynacl==1.4.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ wheel>=0.35.1
 flake8==3.8.4
 tox==3.20.1
 coverage==5.3
-Sphinx==3.3.0
+Sphinx==3.3.1
 twine>=3.2.0
 pytest==6.1.2
 pytest-runner==5.2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 """The setup script."""
 import os
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages  # type: ignore
 
 import cookietemple as module
 

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/cookiejar/cookietemple',
-    version='1.0.1',
+    version='1.2.0',
     zip_safe=False,
 )

--- a/tests/bump_version/test_bump_version.py
+++ b/tests/bump_version/test_bump_version.py
@@ -1,4 +1,6 @@
 import re
+from typing import Tuple
+
 import pytest
 import os
 from pathlib import Path
@@ -22,7 +24,7 @@ def test_bump_version(mocker, valid_version_bumpers) -> None:
     NOTE: If you edit the test files, you must edit the ranges here to (initially versions[0-9] are bumped, the rest should not be bumped)
     """
     mocker.patch.object(Path, 'cwd', autospec=True)
-    Path.cwd.return_value = str(os.path.abspath(os.path.dirname(__file__)))
+    Path.cwd.return_value = str(os.path.abspath(os.path.dirname(__file__)))  # type: ignore
     version_bumper = VersionBumper(Path(str(os.path.abspath(os.path.dirname(__file__)))), downgrade=False)
 
     for version in valid_version_bumpers:
@@ -56,7 +58,7 @@ def test_bad_dir_throws_error() -> None:
     assert result.exit_code != 0
 
 
-def get_file_versions_after_bump(cwd: Path) -> (list, list):
+def get_file_versions_after_bump(cwd: Path) -> Tuple[list, list]:
     """
     Read all version numbers and test whether they were correctly bumped (or not bumped if tagged/not matched)
     :param cwd: Current Working Dir

--- a/tests/general/util/test_util_dict.py
+++ b/tests/general/util/test_util_dict.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest  # type: ignore
 
 from cookietemple.util.dict_util import (delete_keys_from_dict, is_nested_dictionary)
 

--- a/tests/info/test_info_command.py
+++ b/tests/info/test_info_command.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import pytest
 
 from click.testing import CliRunner
@@ -193,7 +195,7 @@ def test_valid_handles_domain_and_subdomain(get_valid_handles_domain_subdomain, 
         out, err = capfd.readouterr()
 
         # first entry of value list are expected handles present in output second are the ones that should not be in output
-        switcher = {
+        switcher: Dict[str, list] = {
             'cli-python': [['cli-python'], 'cli-java'],
             'cli-java': [['cli-java'], 'cli-python'],
             'gui-java': [['gui-java']],


### PR DESCRIPTION
Cookietemple 1.2.0 Release

**Added**
linter for cookietemple.cfg file to ensure integrity
a path parameter to create projects on other locations than the CWD

**Fixed**
sync workflow
java templates WFs due to a GithubActions update
default branch creation when creating and pushing a project to GitHub
updated documentation
web template deployment script (refactored) and workflows

**Dependencies**

**Deprecated**
GitHub PAT with only repo scope (needs workflows permissions now too)

