### PR TITLE
Remove emoticons from release-drafter.yml (Closes #749)

### DIFF
--- a/cookietemple/create/templates/common_files/{{cookiecutter.commonName}}/.github/release-drafter.yml
+++ b/cookietemple/create/templates/common_files/{{cookiecutter.commonName}}/.github/release-drafter.yml
@@ -1,16 +1,16 @@
-name-template: "{{ cookiecutter.version }} 🌈" # <<COOKIETEMPLE_FORCE_BUMP>>
+name-template: "{{ cookiecutter.version }}" # <<COOKIETEMPLE_FORCE_BUMP>>
 tag-template: {{ cookiecutter.version }} # <<COOKIETEMPLE_FORCE_BUMP>>
 categories:
-    - title: "🚀 Features"
+    - title: "Features"
       labels:
           - feature
           - enhancement
-    - title: "🐛 Bug Fixes"
+    - title: "Bug Fixes"
       labels:
           - fix
           - bugfix
           - bug
-    - title: "🧰 Maintenance"
+    - title: "Maintenance"
       label: chore
     - title: ":package: Dependencies"
       labels:


### PR DESCRIPTION
Please see https://github.com/cookiejar/cookietemple/issues/749#issuecomment-891090677 for the detailed explanation about this issue. Short version is that (at least on my French Windows installation) the emoticons used in the `release-drafter.yml` file caused the creation of a new project to fail with a Traceback when Linting the freshly created project. Removing the emoticons bypasses this project (but makes for a slightly less colorful project)

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [X] This comment contains a description of changes (with reason)
  * Explained in details in https://github.com/cookiejar/cookietemple/issues/749
-   [X] Referenced issue is linked
  * https://github.com/cookiejar/cookietemple/issues/749
-   [X] If you've fixed a bug or added code that should be tested, add tests!
  * This apparently (since it wasn't reported, and others are likely using the program) isn't easily reproducible, I would be unsure how to test this.
-   [X] Documentation in `docs` is updated
  * This change doesn't need to be documented specifically

**Description of changes**

Removed the emoticons used in the `release-drafter.yml` file.

**Technical details**

Details in https://github.com/cookiejar/cookietemple/issues/749#issuecomment-891090677

**Additional context**

None
