### PR TITLE
Deleting temporary files fails silently (closes #748)

### DIFF
--- a/cookietemple/create/template_creator.py
+++ b/cookietemple/create/template_creator.py
@@ -351,7 +351,11 @@ class TemplateCreator:
         # delete the tmp cookiecuttered common files directory
         log.debug("Delete common files directory.")
         delete_dir_tree(Path(f"{Path.cwd()}/common_files_util"))
-        shutil.rmtree(dirpath)
+        try:
+            shutil.rmtree(dirpath)
+        except PermissionError:
+            # If deleting these temporary files fails, fail silently (#748)
+            pass
         # change to recent cwd so lint etc can run properly
         os.chdir(str(cwd_project))
 


### PR DESCRIPTION
**Associated Template/Command/Core**

Fixes an issue when running the `create` command for a new project (apparently only on Windows 10 [Enterprise]).
See linked issue #748 for more details.

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [X] This comment contains a description of changes (with reason)
  - Contained in the linked issue
-   [X] Referenced issue is linked
    - Yes, see above.
-   [X] If you've fixed a bug or added code that should be tested, add tests!
  - Not sure how to reproduce this bug (plaftorm related)
-   [X] Documentation in `docs` is updated
  - This change doesn't require user-facing documentation

**Description of changes**

See linked issue #748, short version: if deleting the temporary folder fails with a `PermissionError`, just ignore that and continue the process. These temporary files will be deleted upon the next reboot of the machine anyway.

**Technical details**

Seems to only have been happening on Windows 10 (Enterprise), but handling this exception for all platforms makes sense: even if this happened on Linux or MacOS, the user would likely just want to continue on with the creation of his project, not have to care why deleting temporary files failed.

**Additional context**

None