### PR TITLE
Add docs to pre-commit exclude for end of file fixer

### DIFF
--- a/cookietemple/create/templates/cli/cli_python/{{ cookiecutter.project_slug_no_hyphen }}/.pre-commit-config.yaml
+++ b/cookietemple/create/templates/cli/cli_python/{{ cookiecutter.project_slug_no_hyphen }}/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
             language: system
             types: [text]
             stages: [commit, push, manual]
+            exclude: docs/
           - id: flake8
             name: flake8
             entry: flake8


### PR DESCRIPTION
Sphinx built docs may not always include a last line and therefore the end of file fixer will complain every time the docs were built from scratch.