### PR TITLE
Feature: Suggest version for bump-version

### DIFF
--- a/cookietemple/__main__.py
+++ b/cookietemple/__main__.py
@@ -296,37 +296,35 @@ def bump_version(ctx, new_version, project_dir, downgrade) -> None:
     Unless the user uses downgrade mode via the -d flag, a downgrade of a version is never allowed. Note that bump-version with the new version
     equals the current version is never allowed, either with or without -d.
     """
+    version_bumper = VersionBumper(project_dir, downgrade)
+    # suggest valid version if none was given
     if not new_version:
-        HelpErrorHandling.args_not_provided(ctx, "bump-version")
-    else:
-        # if the path entered ends with a trailing slash remove it for consistent output
-        if str(project_dir).endswith("/"):
-            project_dir = Path(str(project_dir).replace(str(project_dir)[len(str(project_dir)) - 1 :], ""))
+        new_version = version_bumper.choose_valid_version()
+    # if the path entered ends with a trailing slash remove it for consistent output
+    if str(project_dir).endswith("/"):
+        project_dir = Path(str(project_dir).replace(str(project_dir)[len(str(project_dir)) - 1 :], ""))
 
-        version_bumper = VersionBumper(project_dir, downgrade)
-        # lint before run bump-version
-        version_bumper.lint_before_bump()
-        # only run bump-version if conditions are met
-        if version_bumper.can_run_bump_version(new_version):
-            # only run "sanity" checker when the downgrade flag is not set
-            if not downgrade:
-                # if the check fails, ask the user for confirmation
-                if version_bumper.check_bump_range(
-                    version_bumper.CURRENT_VERSION.split("-")[0], new_version.split("-")[0]
-                ):
-                    version_bumper.bump_template_version(new_version, project_dir)
-                elif cookietemple_questionary_or_dot_cookietemple(
-                    function="confirm",
-                    question=f"Bumping from {version_bumper.CURRENT_VERSION} to {new_version} seems not reasonable.\n"
-                    f"Do you really want to bump the project version?",
-                    default="n",
-                ):
-                    console.print("\n")
-                    version_bumper.bump_template_version(new_version, project_dir)
-            else:
+    # lint before run bump-version
+    version_bumper.lint_before_bump()
+    # only run bump-version if conditions are met
+    if version_bumper.can_run_bump_version(new_version):
+        # only run "sanity" checker when the downgrade flag is not set
+        if not downgrade:
+            # if the check fails, ask the user for confirmation
+            if version_bumper.check_bump_range(version_bumper.CURRENT_VERSION.split("-")[0], new_version.split("-")[0]):
+                version_bumper.bump_template_version(new_version, project_dir)
+            elif cookietemple_questionary_or_dot_cookietemple(
+                function="confirm",
+                question=f"Bumping from {version_bumper.CURRENT_VERSION} to {new_version} seems not reasonable.\n"
+                f"Do you really want to bump the project version?",
+                default="n",
+            ):
+                console.print("\n")
                 version_bumper.bump_template_version(new_version, project_dir)
         else:
-            sys.exit(1)
+            version_bumper.bump_template_version(new_version, project_dir)
+    else:
+        sys.exit(1)
 
 
 @cookietemple_cli.command(short_help="Create a self contained executable.", cls=CustomHelpSubcommand)

--- a/cookietemple/bump_version/bump_version.py
+++ b/cookietemple/bump_version/bump_version.py
@@ -280,3 +280,22 @@ class VersionBumper:
                 function="confirm", question="Do you really want to continue?", default="n"
             ):
                 sys.exit(1)
+
+    def choose_valid_version(self) -> str:
+        version_split = self.CURRENT_VERSION.split(".")
+        new_patch, new_minor, new_major = (
+            str(int(version_split[2]) + 1),
+            str(int(version_split[1]) + 1),
+            str(int(version_split[0]) + 1),
+        )
+        version_split_patch = [version_split[0], version_split[1], new_patch]
+        version_split_minor = [version_split[0], new_minor, "0"]
+        version_split_major = [new_major, "0", "0"]
+
+        new_version = cookietemple_questionary_or_dot_cookietemple(
+            function="select",
+            question="Choose the new project version:",
+            choices=[".".join(version_split_patch), ".".join(version_split_minor), ".".join(version_split_major)],
+            default="cli",
+        )
+        return new_version  # type:ignore

--- a/cookietemple/custom_cli/click.py
+++ b/cookietemple/custom_cli/click.py
@@ -169,13 +169,6 @@ class HelpErrorHandling(click.Group):
             )
             sys.exit(1)
 
-        elif cmd == "bump-version":
-            print(
-                f"[bold red]Failed to execute [bold green]{cmd}.\n[bold blue]Please provide a new version like [bold green]1.2.3 "
-                "[bold blue]as first argument."
-            )
-            sys.exit(1)
-
         elif cmd == "config":
             print(
                 f"[bold red]Failed to execute [bold green]{cmd}.\n[bold blue]Please provide a valid argument. You can choose general, pat or all."

--- a/docs/bump_version.rst
+++ b/docs/bump_version.rst
@@ -45,6 +45,9 @@ The :code:`bump-version` command follows the syntax
 
    bump-version applied to a fresh cli-python project
 
+Note that you can use ``bump-version`` without passing any parameters. This way, cookietemple will let you choose from three valid options
+to bump your projects version. Note that this will only work in the main directory of your project due to some cli constraints.
+
 Flags
 -------
 


### PR DESCRIPTION
<!-- Many thanks for contributing to cookietemple! -->

**Associated Template/Command/Core**

<!-- State the template handle or command. -->

`bump-version`

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] This comment contains a description of changes (with reason)
-   [x] Referenced issue is linked
-   [x] Documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->
Calling `cookietemple bump-version` will now allow not passing a version parameter without throwing an error.
Instead, it will suggest three valid options to choose from.

**Technical details**

<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

This will only work from the main (head) directory of the project due to some constrains on how click allows passing of cli parameters.