### PR TITLE
[FEATURE] #823: Create commit tag for bump version (opt-in)

### DIFF
--- a/cookietemple/__main__.py
+++ b/cookietemple/__main__.py
@@ -274,6 +274,7 @@ def sync(project_dir, set_token, pat, username, check_update) -> None:
     cls=CustomArg,
 )  # type: ignore
 @click.option("--downgrade", "-d", is_flag=True, help="Set this flag to downgrade a version.")
+@click.option("--tag", "-t", is_flag=True, help="Create a git tag for the bump commit.")
 @click.option(
     "--project-version",
     is_flag=True,
@@ -283,7 +284,7 @@ def sync(project_dir, set_token, pat, username, check_update) -> None:
     help="Print your projects version and exit",
 )
 @click.pass_context
-def bump_version(ctx, new_version, project_dir, downgrade) -> None:
+def bump_version(ctx, new_version, project_dir, downgrade, tag) -> None:
     """
     Bump the version of an existing cookietemple project.
 
@@ -295,7 +296,10 @@ def bump_version(ctx, new_version, project_dir, downgrade) -> None:
 
     Unless the user uses downgrade mode via the -d flag, a downgrade of a version is never allowed. Note that bump-version with the new version
     equals the current version is never allowed, either with or without -d.
+
+    Users can create a commit tag for the version bump commit by using the --tag/-t flag.
     """
+    create_tag = True if tag else False
     version_bumper = VersionBumper(project_dir, downgrade)
     # suggest valid version if none was given
     if not new_version:
@@ -312,7 +316,7 @@ def bump_version(ctx, new_version, project_dir, downgrade) -> None:
         if not downgrade:
             # if the check fails, ask the user for confirmation
             if version_bumper.check_bump_range(version_bumper.CURRENT_VERSION.split("-")[0], new_version.split("-")[0]):
-                version_bumper.bump_template_version(new_version, project_dir)
+                version_bumper.bump_template_version(new_version, project_dir, create_tag)
             elif cookietemple_questionary_or_dot_cookietemple(
                 function="confirm",
                 question=f"Bumping from {version_bumper.CURRENT_VERSION} to {new_version} seems not reasonable.\n"
@@ -320,9 +324,9 @@ def bump_version(ctx, new_version, project_dir, downgrade) -> None:
                 default="n",
             ):
                 console.print("\n")
-                version_bumper.bump_template_version(new_version, project_dir)
+                version_bumper.bump_template_version(new_version, project_dir, create_tag)
         else:
-            version_bumper.bump_template_version(new_version, project_dir)
+            version_bumper.bump_template_version(new_version, project_dir, create_tag)
     else:
         sys.exit(1)
 

--- a/cookietemple/bump_version/bump_version.py
+++ b/cookietemple/bump_version/bump_version.py
@@ -39,7 +39,7 @@ class VersionBumper:
             )
             sys.exit(1)
 
-    def bump_template_version(self, new_version: str, project_dir: Path) -> None:
+    def bump_template_version(self, new_version: str, project_dir: Path, create_tag: bool) -> None:
         """
         Update the version number for all files that are whitelisted in the config file or explicitly allowed in the blacklisted section.
 
@@ -48,10 +48,12 @@ class VersionBumper:
         separated by two dots.
         Optional is the -SNAPSHOT at the end (for JVM templates especially). NOTE that versions like 1.2.3.4 or 1.2 WILL NOT be recognized as valid versions as
         well as no substring of them will be recognized.
+
         :param new_version: The new version number that should replace the old one in a cookietemple project
         :param project_dir: The default value is the current working directory, so we´re initially assuming the user
                              bumps the version from the projects top level directory. If this is not the case this parameter
                              shows the path where the projects top level directory is and bumps the version there
+        :param create_tag: Whether to create a tag for the commit (if project has a git repo) or not
         """
         log.debug(f"Current version: {self.CURRENT_VERSION} --- New version: {new_version}")
         sections = ["bumpversion_files_whitelisted", "bumpversion_files_blacklisted"]
@@ -104,6 +106,9 @@ class VersionBumper:
             # git commit
             print("[bold blue]Committing changes to local git repository.")
             repo.index.commit(f"Bump version from {self.CURRENT_VERSION} to {new_version}")
+            if create_tag:
+                print("[bold blue]Creating tag for bump version commit.")
+                repo.create_tag(f"{new_version}", message=f"Bump from {self.CURRENT_VERSION} to {new_version}")
 
     @staticmethod
     def replace(file_path: str, subst: str, section: str) -> Tuple[bool, str]:

--- a/docs/bump_version.rst
+++ b/docs/bump_version.rst
@@ -59,6 +59,10 @@ Flags
 
   No version bumping will be triggered. Using this flag will cancel any commands executed after and exits the program.
 
+- ``--tag`` or ``-t`` : To tag the bump version commit.
+
+  One can use this flag to tag the current bump version commit with the updated version for reuse in releases. Note that this will require to be pushed from local to remote by using ``git push origin <tagname>``.
+
 .. _bump-version-configuration:
 
 Configuration

--- a/tests/bump_version/test_bump_version.py
+++ b/tests/bump_version/test_bump_version.py
@@ -38,7 +38,7 @@ def test_bump_version(mocker, valid_version_bumpers) -> None:
     version_bumper = VersionBumper(Path(str(os.path.abspath(os.path.dirname(__file__)))), downgrade=False)
 
     for version in valid_version_bumpers:
-        version_bumper.bump_template_version(version, Path(str(os.path.abspath(os.path.dirname(__file__)))))
+        version_bumper.bump_template_version(version, Path(str(os.path.abspath(os.path.dirname(__file__)))), False)
         versions_whitelisted, versions_blacklisted = get_file_versions_after_bump(Path.cwd())
 
         assert (


### PR DESCRIPTION
<!-- Many thanks for contributing to cookietemple! -->

**Associated Template/Command/Core**

<!-- State the template handle or command. -->

bump-version

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] This comment contains a description of changes (with reason)
-   [x] Referenced issue is linked
-   [x] Documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->

- added -t/--tag flag to bump version command

- using this flag will tag the bump version commit with the current version (if project is a git repo)